### PR TITLE
USDBTC should have 8 decimals of precision

### DIFF
--- a/UMIPs/umip-7.md
+++ b/UMIPs/umip-7.md
@@ -38,7 +38,7 @@ The definition of these identifiers should be:
 
 - Exchanges: Binance, Coinbase, Bitstamp
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
-- Price Steps: 0.00001 (5 decimals in more general trading format)
+- Price Steps: 0.000000001 (8 decimals in more general trading format)
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down


### PR DESCRIPTION
5 is not enough to express enough precision