### PR TITLE
Updating GASETH UMIP with an additional calculation implementation

### DIFF
--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -101,7 +101,7 @@ DECLARE block_count int64;
 DECLARE max_block int64;
 
 -- Querying for the amount of blocks in the preset time range. This will allow block_count to be compared against a given minimum block amount.
-SET (block_count, max_block) = (SELECT AS STRUCT (MAX(number) - MIN(number)), MAX(number) FROM `bigquery-public-data.crypto_ethereum.blocks` WHERE timestamp BETWEEN TIMESTAMP(t2) AND TIMESTAMP(t1));
+SET (block_count, max_block) = (SELECT AS STRUCT (MAX(number) - MIN(number)), MAX(number) FROM `bigquery-public-data.crypto_ethereum.blocks` WHERE timestamp BETWEEN TIMESTAMP(@t2) AND TIMESTAMP(@t1));
 
 CREATE TEMP TABLE cum_gas (
   gas_price int64,
@@ -121,8 +121,8 @@ INSERT INTO cum_gas (
     FROM
       `bigquery-public-data.crypto_ethereum.transactions`
     WHERE block_timestamp 
-    BETWEEN TIMESTAMP(t2)
-    AND TIMESTAMP(t1)  
+    BETWEEN TIMESTAMP(@t2)
+    AND TIMESTAMP(@t1)  
     GROUP BY
       gas_price));
 ELSE -- If a minimum threshold of blocks is not met, query for the minimum amount of blocks
@@ -137,7 +137,7 @@ INSERT INTO cum_gas (
     FROM
       `bigquery-public-data.crypto_ethereum.transactions`
     WHERE block_number 
-    BETWEEN (max_block - B)
+    BETWEEN (max_block - @B)
     AND max_block
     GROUP BY
       gas_price));

--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -132,7 +132,7 @@ select cum_sum, gas_price from cum_gas where cum_sum > halfway order by gas_pric
 ```
 If `block_amount` falls below the minimum number of mined blocks, a reporter should medianize over a range defined by the minimum number of blocks, rather than the current time range. This is explained further in the *Rationale* section.
 
-These implementations are provided for explanation purposes and as convenient ways for DVM reporters to calculate the GASETH price identifiers. DVM reporters are free to develop additional implementations, as long as they agree with the computation methodology defined in the *Rationale* section and specifications of the *Technical Specifications* section.
+These implementations are provided for explanation purposes and as convenient ways for DVM reporters to calculate the GASETH price identifiers. DVM reporters are free to develop additional implementations, as long as the implementations agree with the computation methodology defined in the *Rationale* section and specifications of the *Technical Specifications* section.
 
 ## Security considerations
 

--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -94,7 +94,30 @@ def return_median(t, N)
 declare halfway int64;
 declare block_range int64;
 
-create temp table cum_gas as (SELECT gas_price, block_number, SUM(gas_used) OVER (ORDER BY gas_price) AS cum_sum FROM (SELECT gas_price, block_number, SUM(receipt_gas_used) AS gas_used FROM `bigquery-public-data.crypto_ethereum.transactions` WHERE block_timestamp BETWEEN TIMESTAMP('2020-10-13 22:00:00', 'UTC') AND TIMESTAMP('2020-10-14 22:00:00', 'UTC') GROUP BY gas_price, block_number));
+create temp table cum_gas as (
+    SELECT
+        gas_price,
+        block_number,
+        SUM(gas_used) OVER (
+            ORDER BY
+                gas_price
+        ) AS cum_sum
+    FROM
+        (
+            SELECT
+                gas_price,
+                block_number,
+                SUM(receipt_gas_used) AS gas_used
+            FROM
+                `bigquery-public-data.crypto_ethereum.transactions`
+            WHERE
+                block_timestamp BETWEEN TIMESTAMP('2020-10-13 22:00:00', 'UTC')
+                AND TIMESTAMP('2020-10-14 22:00:00', 'UTC')
+            GROUP BY
+                gas_price,
+                block_number
+        )
+);
   
 set halfway = (SELECT DIV(MAX(cum_sum),2) from cum_gas);
 

--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -12,7 +12,7 @@ The DVM should support requests for aggregatory gas prices on the Ethereum block
 ## Motivation
 The DVM currently does not support reporting aggregatory gas prices of finalized blocks on the Ethereum blockchain. 
 
-Cost: Calculating an aggregatory statistic of gas prices on a confirmed block or range of blocks on the Ethereum blockchain is easy by virtue of the fact that all needed data is readily available on any Ethereum full node, whether run locally or accessed remotely through well-known providers such as Infura or Alchemy.
+Cost: Calculating an aggregatory statistic of gas prices on a confirmed block or range of blocks on the Ethereum blockchain is easy by virtue of the fact that all needed data is readily available on any Ethereum full node, whether run locally or accessed remotely through well-known providers such as Infura or Alchemy. Additionally, this data can be accessed through querying publicly accessible Ethereum blockchain data sets. 
 
 Opportunity: Gas options/futures can help users and developers hedge against gas volatility allowing them to budget their gas consumption efficiently. Providing a price feed for settlement is a prerequisite.
 
@@ -22,7 +22,7 @@ The definition of this identifier should be:
 - Identifier name: GASETH-1HR GASETH-4HR GASETH-1D GASETH-1W GASETH-1M 
 - Base Currency: ETH
 - Quote Currency: GAS
-- Sources: any Ethereum full node
+- Sources: any Ethereum full node or data set of Ethereum node data
 - Result Processing: Exact
 - Input Processing: see Implementation section
 - Price Steps: 1 Wei (1e-18)
@@ -52,7 +52,7 @@ For example, if the GASETH-1HR is requested for `t1` = October 1st 2020 UTC 00:0
 
 ## Implementation
 
-The total gas used over the last 300 (GASETH-1HR), 1200 (GASETH-4HR) or 7200 (GASETH-24HR) blocks that were mined at or before the `timestamp` provided to DVM is computed. Transactions in this range are also sorted by `total_gas_consumed`. 
+The total gas used by the blocks that were mined over the identifier specific time interval is computed. The identifier specific time interval is defined with bounds of the `timestamp` provided to DVM and the `timestamp` less 1HR (GASETH-1HR), 4HR (GASETH-4HR), 24HR (GASETH-1D), 168HR (GASETH-1W) or 720HR (GASETH-1M). Transactions in this range are also sorted by `total_gas_consumed`. 
 
 The pseudo-algorithm to calculate the exact data point to report by a DVM reporter is as follows:
 

--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -147,7 +147,7 @@ SET halfway = (SELECT DIV(MAX(cum_sum),2) FROM cum_gas);
 
 SELECT cum_sum, gas_price FROM cum_gas WHERE cum_sum > halfway ORDER BY gas_price LIMIT 1;
 ```
-If `block_count` falls below the minimum number of mined blocks, the query medianize over a range defined by the minimum number of blocks, rather than the given time range. This is explained further in the *Rationale* section.
+If `block_count` falls below the minimum number of mined blocks, the query will medianize over a range defined by the minimum number of blocks, rather than the given time range. This is explained further in the *Rationale* section.
 
 These implementations are provided for explanation purposes and as convenient ways for DVM reporters to calculate the GASETH price identifiers. DVM reporters are free to develop additional implementations, as long as the implementations agree with the computation methodology defined in the *Rationale* section and specifications of the *Technical Specifications* section.
 

--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -109,7 +109,7 @@ CREATE TEMP TABLE cum_gas (
 );
 
 -- If the minimum threshold of blocks is met, query on a time range
-IF block_count >= B THEN
+IF block_count >= @B THEN
 INSERT INTO cum_gas (
   SELECT
     gas_price,

--- a/UMIPs/umip-17.md
+++ b/UMIPs/umip-17.md
@@ -1,9 +1,9 @@
 ## Headers
-| UMIP-##   |                                                                                                                                          |
+| UMIP-17   |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | UMIP Title | Add rDAI as a collateral currency              |
-| Authors    | Jeff Bennett (endymionjkb@gmail.com) |
-| Status     | Draft                                                                                                                                    |
+| Authors    | Jeff Bennett (endymionjkb@gmail.com), Sean Brown (@smb2796) |
+| Status     | Last Call                                                                                                                                    |
 | Created    | September 25, 2020                                                                                                                           |
 
 ## Summary (2-5 sentences)


### PR DESCRIPTION
Using a Google BigQuery query that @mrice32 created,  I have added another reference implementation. This will allow for flexibility in the actual usage of this price identifier. I also attempt to make it explicit that DVM reporters are free to define their own implementations of this calculation later, so long as those implementations agree with the calculation methodology. 