### PR TITLE
Update price identifier decimals and deprecate legacy price IDs

### DIFF
--- a/UMIPs/umip-13.md
+++ b/UMIPs/umip-13.md
@@ -28,6 +28,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18
 
 The definition of this identifier should be:
 - Identifier name: USDPERL
@@ -40,8 +41,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
-
-
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 

--- a/UMIPs/umip-16.md
+++ b/UMIPs/umip-16.md
@@ -30,6 +30,7 @@ The definition of this identifier should be:
 - Pricing Interval: 1 second
 - Dispute timestamp rounding: down
 - Output processing: None
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 

--- a/UMIPs/umip-19.md
+++ b/UMIPs/umip-19.md
@@ -32,6 +32,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 300 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 Prices are primarily used by Priceless contracts to calculate a synthetic token’s redemptive value in case of liquidation or expiration. Contract counterparties also use the price index to ensure that sponsors are adequately collateralized. 

--- a/UMIPs/umip-2.md
+++ b/UMIPs/umip-2.md
@@ -33,6 +33,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 We explored two primary alternative designs:

--- a/UMIPs/umip-20.md
+++ b/UMIPs/umip-20.md
@@ -28,6 +28,7 @@ The definition of this identifier should be:
 - Pricing Interval: 1 second
 - Dispute timestamp rounding: down
 - Output processing: None
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 

--- a/UMIPs/umip-21.md
+++ b/UMIPs/umip-21.md
@@ -35,10 +35,11 @@ Result Processing: (100.00 - BTCDOM)
 
 Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus. Live data will be cached from CoinGecko on the (1-3 minute) interval in order to backlog 96 hours of historical data to allow for the successful deployment of liquidation and dispute bots.
 
-Price Steps: `00.01`  
-Rounding: Round to nearest 2 decimal places (third decimal place digit >= 5 rounds up and < 5 rounds down)  
-Pricing Interval: 1 minute  
-Dispute timestamp rounding: down (UTC)  
+- Price Steps: `00.01`  
+- Rounding: Round to nearest 2 decimal places (third decimal place digit >= 5 rounds up and < 5 rounds down)  
+- Pricing Interval: 1 minute  
+- Dispute timestamp rounding: down (UTC)
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 

--- a/UMIPs/umip-22.md
+++ b/UMIPs/umip-22.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state. Price requests from new contracts to the DVM for this identifier will likely not be resolved correctly. 
+
+Reasoning: the specified timestamp is outdated. 
+
 # Headers
 | UMIP-22     |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -36,6 +42,7 @@ The definition of this identifier should be:
 - Post-Timestamp Price Rounding: Closest, 0.5 up
 - Pricing Interval: 1 second
 - Dispute timestamp rounding: down
+- Scaling Decimals: (1e18)
 
 ## Rationale
 

--- a/UMIPs/umip-23.md
+++ b/UMIPs/umip-23.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier. 
+
 ## Headers
 | UMIP-23     |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -32,6 +38,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 8 (1e8)
  
 ## Rationale
 Prices are primarily used by Priceless contracts to calculate a synthetic token’s redemptive value in case of liquidation or expiration. Contract counterparties also use the price index to ensure that sponsors are adequately collateralized.

--- a/UMIPs/umip-23.md
+++ b/UMIPs/umip-23.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests for this identifier from contracts created after 02/26/21 00:00 UTC will likely not be resolved correctly. Price requests from contracts created before this time will not be impacted.
 
 Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier. 
 

--- a/UMIPs/umip-24.md
+++ b/UMIPs/umip-24.md
@@ -29,7 +29,7 @@ Adding TVL identifiers enables the creation of synthetic assets with a price tha
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad consensus.
 - Rounding: Round to nearest 3 decimal places (fourth decimal place digit >= 5 rounds up and < 5 rounds down)
 - Intended Collateral Type: USDC
-- Collateral Decimals: 6
+- Scaling Decimals: 18 (1e18)
 - Pricing Interval: 60 minutes
 - Dispute timestamp rounding: down 
 
@@ -41,7 +41,7 @@ Adding TVL identifiers enables the creation of synthetic assets with a price tha
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad consensus.
 - Rounding: Round to nearest 3 decimal places (fourth decimal place digit >= 5 rounds up and < 5 rounds down)
 - Intended Collateral Type: USDC
-- Collateral Decimals: 6
+- Scaling Decimals: 18 (1e18)
 - Pricing Interval: 60 minutes
 - Dispute timestamp rounding: down 
 

--- a/UMIPs/umip-25.md
+++ b/UMIPs/umip-25.md
@@ -29,6 +29,7 @@ The motivation for these price identifiers is explained in [umip-22](https://git
 ## Technical Specification
 Technical specifications are the same as in [umip-22](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-22.md) except: 
 - Identifier name: GASETH-FEB21 and GASETH-MAR21
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 Please reference the Rationale section in [umip-22](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-22.md) for a full walkthrough of the rationale behind calculating aggregatory gas prices.

--- a/UMIPs/umip-26.md
+++ b/UMIPs/umip-26.md
@@ -35,6 +35,7 @@ The definition of this identifier should be:
 * Rounding: Closest, 0.5 up
 * Pricing Interval: 60 seconds
 * Dispute timestamp rounding: down
+* Scaling Decimals: 18 (1e18)
 
  And
 
@@ -48,6 +49,7 @@ The definition of this identifier should be:
 * Rounding: Closest, 0.5 up
 * Pricing Interval: 60 seconds
 * Dispute timestamp rounding: down
+* Scaling Decimals: 18 (1e18)
 
 ## Implementation
 The value of the XAUUSD or XAUPERL identifier for a given timestamp should be determined by querying for the price of XAUUSD from Tradermade’s API for that timestamp. To determine the value of XAUPERL, the price of PERLUSDT will also need to be queried from Binance for that timestamp.

--- a/UMIPs/umip-28.md
+++ b/UMIPs/umip-28.md
@@ -35,6 +35,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 1 second
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
  
 ## Rationale
 Prices are primarily used by Priceless contracts to calculate a synthetic token’s redemptive value in case of liquidation or expiration. Contract counterparties also use the price index to ensure that sponsors are adequately collateralized.

--- a/UMIPs/umip-30.md
+++ b/UMIPs/umip-30.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+
 ## Headers
 | UMIP-30     |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -35,6 +41,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 1 second
 - Dispute timestamp rounding: down
+- Scaling Decimals: 6 (1e6)
  
 ## Rationale
 Prices are primarily used by Priceless contracts to calculate a synthetic token’s redemptive value in case of liquidation or expiration. Contract counterparties also use the price index to ensure that sponsors are adequately collateralized.

--- a/UMIPs/umip-30.md
+++ b/UMIPs/umip-30.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests for this identifier from contracts created after 02/26/21 00:00 UTC will likely not be resolved correctly. Price requests from contracts created before this time will not be impacted. 
 
 Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
 

--- a/UMIPs/umip-31.md
+++ b/UMIPs/umip-31.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6) or renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+
 ## Headers
 | UMIP-31     |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -28,12 +34,12 @@ The definition of this identifier should be:
 - Identifier name: STABLESPREAD/USDC
 - Base Currency: STABLESPREAD
 - Quote Currency: USDC
-- Decimals: 6
+- Scaling Decimals: 6 (1e6)
 
 - Identifier name: STABLESPREAD/BTC
 - Base Currency: STABLESPREAD
 - Quote Currency: BTC
-- Decimals: 8
+- Scaling Decimals: 8 (1e8)
 
 - Data Sources: {Bittrex: UST/USDT, Uniswap V2: UST/USDT} for UST, {Binance: BUSD/USDT, Uniswap V2: BUSD/USDT} for BUSD, {Bittrex: CUSD/USDT} for CUSD, {Bitfinex: UST/USD, Kraken: USDT/USD} for USDT, {Kraken: USDC/USD, Bitstamp: USDC/USD} for USDC, {Kraken: BTC/USD, Bitstamp: BTC/USD} for BTC
 - Result Processing: For each constituent asset of the basket, the average of both exchanges

--- a/UMIPs/umip-31.md
+++ b/UMIPs/umip-31.md
@@ -1,8 +1,8 @@
 # Disclaimer
 
-This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+These price identifiers have been deprecated. It is highly recommended that contract deployers do not use these identifiers in their current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
 
-Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6) or renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require these price identifiers to be scaled equal the number of decimals in USDC (6) or renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use either one of these identifiers.
 
 ## Headers
 | UMIP-31     |                                                                                                                                          |

--- a/UMIPs/umip-31.md
+++ b/UMIPs/umip-31.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-These price identifiers have been deprecated. It is highly recommended that contract deployers do not use these identifiers in their current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+These price identifiers have been deprecated. It is highly recommended that contract deployers do not use these identifiers in their current state for new contracts. Price requests for this identifier from contracts created after 02/26/21 00:00 UTC will likely not be resolved correctly. Price requests from contracts created before this time will not be impacted. 
 
 Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require these price identifiers to be scaled equal the number of decimals in USDC (6) or renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use either one of these identifiers.
 

--- a/UMIPs/umip-32.md
+++ b/UMIPs/umip-32.md
@@ -23,13 +23,13 @@ The definition of these identifiers should be:
 - Base Currency: CNY
 - Quote Currency: USD
 - Result Processing: None
-- Collateral Decimals: 18
 - Price Steps: 0.000001 (6 decimals in more general trading format)
 - Date Source: TraderMade
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 10 minutes
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18
 
 
 ## Rationale

--- a/UMIPs/umip-33.md
+++ b/UMIPs/umip-33.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6) or AMPL (9). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+
 ## Headers
 
 - UMIP-33
@@ -30,11 +36,11 @@ The definition of this identifier should be:
 - Data Sources: FTX, Bitfinex, Gate.io
 - Result Processing: Median
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
-- Collateral Decimals: 6
 - Price Steps: 0.000001 (6 decimals in more general trading format)
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 1 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 6 (1e6)
 
 The definition of this identifier should be:
 
@@ -45,10 +51,10 @@ The definition of this identifier should be:
 - Result Processing: Median
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
 - Price Steps: 0.000001 (6 decimals in more general trading format)
-- Collateral Decimals: 9
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 1 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 9 (1e9)
 
 ## Rationale
 

--- a/UMIPs/umip-33.md
+++ b/UMIPs/umip-33.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-The AMPLUSD price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+The AMPLUSD price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests for this identifier from contracts created after 02/26/21 00:00 UTC will likely not be resolved correctly. Price requests from contracts created before this time will not be impacted. 
 
 Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
 

--- a/UMIPs/umip-33.md
+++ b/UMIPs/umip-33.md
@@ -1,8 +1,8 @@
 # Disclaimer
 
-This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+The AMPLUSD price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
 
-Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6) or AMPL (9). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
 
 ## Headers
 
@@ -54,7 +54,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 1 seconds
 - Dispute timestamp rounding: down
-- Scaling Decimals: 9 (1e9)
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 

--- a/UMIPs/umip-37.md
+++ b/UMIPs/umip-37.md
@@ -26,10 +26,10 @@ The definition of this identifier should be:
 - Intended collateral currency: USDC
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
 - Price Steps: 6 decimals
-
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 The definition of this identifier should be:
 - Identifier name: USDDSD
@@ -40,10 +40,10 @@ The definition of this identifier should be:
 - Result Processing: 1/DSDUSD.
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
 - Price Steps: 18 decimals
-
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 Note :- We are assuming that the price of 1 USDC is approximately equal to 1 USD.
 

--- a/UMIPs/umip-38.md
+++ b/UMIPs/umip-38.md
@@ -1,8 +1,8 @@
 # Disclaimer
 
-This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+These price identifiers have been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
 
-Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require these price identifiers to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use either one of these identifiers.
 
 ## Headers
 - UMIP-38

--- a/UMIPs/umip-38.md
+++ b/UMIPs/umip-38.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-These price identifiers have been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+These price identifiers have been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests for this identifier from contracts created after 02/26/21 00:00 UTC will likely not be resolved correctly. Price requests from contracts created before this time will not be impacted.
 
 Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require these price identifiers to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use either one of these identifiers.
 

--- a/UMIPs/umip-38.md
+++ b/UMIPs/umip-38.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require this price identifier to be scaled equal the number of decimals in USDC (6). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier.
+
 ## Headers
 - UMIP-38
 - UMIP title: Add price identifiers COMPUSDC-APR-FEB28/USDC and COMPUSDC-APR-MAR28/USDC
@@ -60,7 +66,6 @@ This price should be queried from the highest volume Uniswap pool (Whichever one
 
 The source of truth for this data is the Compound USDC cToken's (cUSDC) `borrowRatePerBlock()` method. As of the writing of this UMIP, the agreed-upon cUSDC smart contract address is `0x39aa39c021dfbae8fac545936693ac917d5e7563`. This price identifier aggregates the value returned by `borrowRatePerBlock()` over every block from the 30 days ending at the cutoff/expiration timestamp (`1614470400` for `COMPUSDC-APR-FEB28/USDC` and `1616889600` for `COMPUSDC-APR-MAR28/USDC`).
 
-
 It is recommended to gather the raw data from an Ethereum archive node. Alternatively, this data is indexed in the [Graph Protocol](https://thegraph.com/explorer/subgraph/graphprotocol/compound-v2). As of writing this UMIP, Graph Protocol is free. However, they have plans to start charging for access in the future. In the future, querying 30 days worth of blocks may cost up to $20 USD. This UMIP's price identifier will only be used for the DVM to return the synthetic token's expiration price. Therefore, this high price won't be incurred by liquidator bots.
 
 Raw data is also available for download at the [Tendies Exchange public endpoint](https://cache.tendies.exchange/borrow_rate_per_block.json). This endpoint is updated with every new block but delayed by 20 block confirmations. This endpoint is free to use. To generate a similar file, governors can use and/or modify this [open source indexer script](https://github.com/evanmays/tendies-exchange/tree/master/indexer).
@@ -91,7 +96,7 @@ The intention is that the aggregated APR won't be used for liquidations. This is
 
 **4. Intended Collateral Currency** - USDC
 
-**5. Collateral Decimals** - 6
+**5. Scaling Decimals** - 6 (1e6)
 
 **6a. Rounding Pre Cutoff** - Round to nearest 2 decimal places (third decimal place digit >= 5 rounds up and < 5 rounds down)
 
@@ -115,7 +120,7 @@ The intention is that the aggregated APR won't be used for liquidations. This is
 
 **4. Intended Collateral Currency** - USDC
 
-**5. Collateral Decimals** - 6
+**5. Scaling Decimals** - 6 (1e6)
 
 **6a. Rounding Pre Cutoff** - Round to nearest 2 decimal places (third decimal place digit >= 5 rounds up and < 5 rounds down)
 

--- a/UMIPs/umip-39.md
+++ b/UMIPs/umip-39.md
@@ -136,7 +136,7 @@ https://github.com/ConcourseOpen/DeFi-Pulse-Adapters/blob/master/projects/badger
 
     - Yes
 
-**5. Collateral Decimals** - 18
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to 18 decimal places
 
@@ -159,7 +159,7 @@ https://github.com/ConcourseOpen/DeFi-Pulse-Adapters/blob/master/projects/badger
 
     - Yes
 
-**5. Collateral Decimals** - 18
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to 18 decimal places
 

--- a/UMIPs/umip-40.md
+++ b/UMIPs/umip-40.md
@@ -114,7 +114,7 @@ The [price feed implementation](https://github.com/UMAprotocol/protocol/pull/245
 
     Yes, it is.
 
-**5. Collateral Decimals** - 6 decimals.
+**5. Scaling Decimals** - 18 (1e18).
 
 **6. Rounding** - Rounded to 6 decimals in accordance with above.
 

--- a/UMIPs/umip-41.md
+++ b/UMIPs/umip-41.md
@@ -58,7 +58,7 @@ This means that only the Uniswap TWAP calculation will need to be queried in rea
 - Base Currency: uVOL-BTC-APR21
 - Quote currency: None. This is an index, but will be used with USDC.
 - Intended Collateral Currency: USDC
-- Collateral Decimals: 6
+- Scaling Decimals: 18 (1e18)
 - Rounding: Round to nearest 6 decimal places (seventh decimal place digit >= 5 rounds up and < 5 rounds down)
 
 ## RATIONALE

--- a/UMIPs/umip-46.md
+++ b/UMIPs/umip-46.md
@@ -75,7 +75,7 @@ Associated OCEAN price feeds are available via Cryptowatch.  No other further fe
 - Base Currency: OCEAN
 - Quote Currency: USD
 - Intended Collateral Currency: USDC
-- Collateral Decimals: 6
+- Scaling Decimals: 18 (1e18)
 - Rounding: Round to nearest 6 decimal places (seventh decimal place digit >= 5 rounds up and < 5 rounds down)
 - Does the value of this collateral currency match the standalone value of the listed quote currency?: YES
 - Is your collateral currency already approved to be used by UMA financial contracts?: YES
@@ -84,11 +84,10 @@ Associated OCEAN price feeds are available via Cryptowatch.  No other further fe
 - Base Currency: USD
 - Quote Currency: OCEAN
 - Intended Collateral Currency: OCEAN
-- Collateral Decimals: 18
+- Scaling Decimals: 18 (1e18)
 - Rounding: Round to nearest 18 decimal places (nineteenth decimal place digit >= 5 rounds up and < 5 rounds down)
 - Does the value of this collateral currency match the standalone value of the listed quote currency?: YES
-- Is your collateral currency already approved to be used by UMA financial contracts?: In progress
-https://github.com/opendao-protocols/UMIPs/blob/umip-oceantoken-collateral/UMIPs/umip-draft_OCEAN_collateral.md
+- Is your collateral currency already approved to be used by UMA financial contracts?: YES
 
 
 ## Rationale

--- a/UMIPs/umip-47.md
+++ b/UMIPs/umip-47.md
@@ -58,7 +58,7 @@ Because the uSTONKS index value is only used at expiry, it will not be possible 
 - Base Currency: uSTONKS_APR21
 - Quote currency: None. This is an index, but will be used with USDC.
 - Intended Collateral Currency: USDC
-- Collateral Decimals: 6
+- Scaling Decimals: 18 (1e18)
 - Rounding: Round to nearest 6 decimal places (seventh decimal place digit >= 5 rounds up and < 5 rounds down)
 
 ## RATIONALE

--- a/UMIPs/umip-48.md
+++ b/UMIPs/umip-48.md
@@ -43,7 +43,7 @@ To further explain the price feed implementation beyond what is stated in [umip-
 
 **4. Intended Collateral Currency** - WETH
 
-**5. Collateral Decimals** - 18 decimals
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to nearest 6 decimal places (seventh decimal place digit >= 5 rounds up and < 5 rounds down)
 

--- a/UMIPs/umip-49.md
+++ b/UMIPs/umip-49.md
@@ -116,7 +116,7 @@ Link to the price feed pull issue:
 
   - Yes, we use DAI
 
-**5. Collateral Decimals** - 18
+**5. Scaling Decimals** - 18 (1e18)
 
 - DAI has 18 Decimals (obtained [here](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f)).
 
@@ -140,7 +140,7 @@ Link to the price feed pull issue:
 
   - Yes, we use DAI
 
-**5. Collateral Decimals** - 18
+**5. Scaling Decimals** - 18 (1e18)
 
 - DAI has 18 Decimals (obtained [here](https://etherscan.io/token/0x6b175474e89094c44da98b954eedeac495271d0f)).
 

--- a/UMIPs/umip-5.md
+++ b/UMIPs/umip-5.md
@@ -29,6 +29,7 @@ The definition of this identifier should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 As of the time of writing, the Coinbase Pro market for $COMPUSD is not yet live, though it is expected to go live on Monday, June 22, 2020. Until the Coinbase Pro market officially goes live and starts trading, the technical specification of this identifier is to take the median of available exchanges (eg Poloniex COMPUSDT and FTX COMPUSD). Once Coinbase Pro is live and stable, the technical specification of this identifier will be the median across Coinbase Pro, Poloniex, and FTX.
 

--- a/UMIPs/umip-50.md
+++ b/UMIPs/umip-50.md
@@ -123,7 +123,7 @@ These price identifiers use the [UniswapPriceFeed](https://github.com/UMAprotoco
 
     - Yes (https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-44.md)
 
-**5. Collateral Decimals** - YAM has 18 decimals (https://etherscan.io/token/0x0aacfbec6a24756c20d41914f2caba817c0d8521)
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to 18 decimal places. 
 
@@ -147,7 +147,7 @@ These price identifiers use the [UniswapPriceFeed](https://github.com/UMAprotoco
 
     - Yes. Per UMIP 18
 
-**5. Collateral Decimals** - USDT, which is used in this calculation, has 6 decimals (https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7)
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to 6 decimal places. 
 
@@ -171,7 +171,7 @@ These price identifiers use the [UniswapPriceFeed](https://github.com/UMAprotoco
 
     - Pending UMIP (https://github.com/UMAprotocol/UMIPs/pull/154)
 
-**5. Collateral Decimals** - YAM has 18 decimals (https://etherscan.io/token/0x0aacfbec6a24756c20d41914f2caba817c0d8521)
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to 18 decimal places.
 
@@ -197,7 +197,7 @@ These price identifiers use the [UniswapPriceFeed](https://github.com/UMAprotoco
 
     - Yes
 
-**5. Collateral Decimals** - ETH has 18 decimals 
+**5. Scaling Decimals** - 18 (1e18)
 
 **6. Rounding** - Round to 18 decimal places. 
 

--- a/UMIPs/umip-51.md
+++ b/UMIPs/umip-51.md
@@ -93,7 +93,7 @@ These price identifiers use the [UniswapPriceFeed](https://github.com/UMAprotoco
 - Intended Collateral Currency: USDC
 - Does the value of this collateral currency match the standalone value of the listed quote currency?: YES
 - Is your collateral currency already approved to be used by UMA financial contracts?: YES
-- Collateral Decimals: 6 decimals
+- Scaling Decimals: 18 (1e18)
 - Rounding: Round to 6 decimals.
 
 ### USDWBTC
@@ -102,7 +102,7 @@ These price identifiers use the [UniswapPriceFeed](https://github.com/UMAprotoco
 - Intended Collateral Currency: WBTC
 - Does the value of this collateral currency match the standalone value of the listed quote currency?: YES
 - Is your collateral currency already approved to be used by UMA financial contracts?: YES
-- Collateral Decimals: 8 decimals
+- Scaling Decimals: 18 (1e18)
 - Rounding: Round to 8 decimals.
 
 ## Rationale

--- a/UMIPs/umip-6.md
+++ b/UMIPs/umip-6.md
@@ -38,6 +38,7 @@ The definition of these identifiers should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 ## Rationale
 Prices are primarily used by Priceless contracts to calculate a synthetic token’s redemptive value in case of liquidation or expiration. Contract counterparties also use the price index to ensure that sponsors are adequately collateralized. 

--- a/UMIPs/umip-7.md
+++ b/UMIPs/umip-7.md
@@ -1,3 +1,9 @@
+# Disclaimer
+
+The USDBTC price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+
+Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require the USDBTC price identifier to be scaled equal the number of decimals in renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier. 
+
 ## Headers
 | UMIP-7     |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -26,6 +32,7 @@ The definition of these identifiers should be:
 - Base Currency: BTC
 - Quote Currency: USD(T)
 - Result Processing: Median
+- Scaling Decimals: 8 (1e18)
 
 -----------------------------------------
 
@@ -33,6 +40,7 @@ The definition of these identifiers should be:
 - Base Currency: USD(T)
 - Quote Currency: BTC
 - Result Processing: 1 / Median BTCUSD
+- Scaling Decimals: 8 (1e8)
 
 -----------------------------------------
 
@@ -42,7 +50,6 @@ The definition of these identifiers should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
-- Scaling Decimals: 18 (1e18)
 
 
 ## Rationale

--- a/UMIPs/umip-7.md
+++ b/UMIPs/umip-7.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-The USDBTC price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests from contracts created after 02/20/21 00:00 UTC will likely not be resolved correctly. 
+The USDBTC price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state for new contracts. Price requests for this identifier from contracts created after 02/26/21 00:00 UTC will likely not be resolved correctly. Price requests from contracts created before this time will not be impacted. 
 
 Reasoning: The new EMP template proposed in [UMIP-54](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) requires that all price identifiers be scaled to 18 decimals. There are live contracts using the old EMP template which require the USDBTC price identifier to be scaled equal the number of decimals in renBTC (8). Because of this, the DVM could return prices incorrectly for new contracts that use this identifier. 
 
@@ -32,7 +32,7 @@ The definition of these identifiers should be:
 - Base Currency: BTC
 - Quote Currency: USD(T)
 - Result Processing: Median
-- Scaling Decimals: 8 (1e18)
+- Scaling Decimals: 18 (1e18)
 
 -----------------------------------------
 

--- a/UMIPs/umip-7.md
+++ b/UMIPs/umip-7.md
@@ -42,6 +42,7 @@ The definition of these identifiers should be:
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down
+- Scaling Decimals: 18 (1e18)
 
 
 ## Rationale


### PR DESCRIPTION
This PR does two things.

1. Adds a deprecation notice for any price identifier that is currently being used in a mainnet contract **AND** has a non-18 decimal scaling specification.
2. Edits all identifiers, that do not follow into the first category, to specify 18 decimals of scaling.

This is necessary because the new [EMP](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-54.md) and [Perp](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-53.md) require that all price identifiers be scaled to 18 decimals. Price identifiers that fall into the first category will resolve incorrectly if used with the new factories, hence the deprecation notices.