### PR TITLE
Update timestamp on GASETH-TWAP-1Mx1M to make it usable

### DIFF
--- a/UMIPs/umip-22.md
+++ b/UMIPs/umip-22.md
@@ -1,9 +1,3 @@
-# Disclaimer
-
-This price identifier has been deprecated. It is highly recommended that contract deployers do not use this identifier in its current state. Price requests from new contracts to the DVM for this identifier will likely not be resolved correctly. 
-
-Reasoning: the specified timestamp is outdated. 
-
 # Headers
 | UMIP-22     |                                                                                                                                          |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -17,9 +11,9 @@ This UMIP will reference a synthetic token to be created with this price identif
 
 The DVM should support requests for a price that resolves to either the median monthly Ethereum gas price or a 2-hour Time-Weighted Average Price (TWAP) on the highest volume Uniswap ETH/uGAS pool. The price resolution method to use will depend on the the timestamp the price request was made at.
 
-For a price request made at or after the Unix timestamp `1612137600` (Feb 1, 2021 00:00:00 UTC), the price will be resolved with the median monthly gas price calculation defined for GASETH-1M-1M in UMIP-20.
+For a price request made at or after the Unix timestamp `1625097600` (Jul 01, 2021 00:00:00 UTC), the price will be resolved with the median monthly gas price calculation defined for GASETH-1M-1M in UMIP-20.
 
-For a price request made before `1612137600`, the price will be resolved to a 2-hour TWAP for the Uniswap price of the listed synthetic token in ETH. The synthetic token address will be listed in the Technical Specification section.
+For a price request made before `1625097600`, the price will be resolved to a 2-hour TWAP for the Uniswap price of the listed synthetic token in ETH. The synthetic token address will be listed in the Technical Specification section.
 
 ## Motivation
 The motivation for calculating aggregatory Ethereum gas prices in a set amount of units of gas is explained in [UMIP-16](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-16.md) and [UMIP-20](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-20.md).
@@ -32,9 +26,9 @@ This pricing structure will allow for the creation of a tokenized futures contra
 
 The definition of this identifier should be:
 - Identifier name: GASETH-TWAP-1Mx1M
-- Base Currency: ETH
-- Quote Currency: GAS OR uGAS
-- Sources: any Ethereum full node or data set of Ethereum node data. ETH/uGAS Uniswap pool price events. 
+- Base Currency: uGAS
+- Quote Currency: ETH
+- Sources: any Ethereum full node or data set of Ethereum node data. uGAS/ETH Uniswap pool price events. 
 - Result Processing: multiply by a million when calculating aggregatory gas prices.
 - Input Processing: See the UMIP-16 Implementation Section. Additionally, if the contract using this price identifier is an expiring contract, inputs will change depending on the price request timestamp in comparison to the expiry timestamp.
 - Price Steps: 1 Wei (1e-18)
@@ -54,7 +48,7 @@ A 2-hour TWAP was chosen to mitigate any risk of attempted price manipulation at
 
 ## Implementation
 
-If the price request's UTC timestamp is less than `1612137600`, voters will need to calculate a 2-hour TWAP for the uGAS token's price in ETH. The following process should be used to calculate the TWAP.
+If the price request's UTC timestamp is less than `1625097600`, voters will need to calculate a 2-hour TWAP for the uGAS token's price in ETH. The following process should be used to calculate the TWAP.
 
 1. The end TWAP timestamp equals the price request timestamp.
 2. The start TWAP timestamp is defined by the end TWAP timestamp minus the TWAP period (2 hours in this case).
@@ -63,7 +57,7 @@ If the price request's UTC timestamp is less than `1612137600`, voters will need
 5. As the token price will already implicitly be tracking the GASETH-1M-1M price, it should be left as returned without any scaling transformation.
 6. The final price should be returned with the synthetic token as the denominator of the price pair and should be submitted with 18 decimals.  
 
-If the price request's UTC timestamp is at or after `1612137600`, a price request for GASETH-TWAP-1Mx1M will follow the calculation methodology for the GASETH-1M-1M identifier defined in the UMIP-20 Rationale and Implementation sections.
+If the price request's UTC timestamp is at or after `1625097600`, a price request for GASETH-TWAP-1Mx1M will follow the calculation methodology for the GASETH-1M-1M identifier defined in the UMIP-20 Rationale and Implementation sections.
 
 For both implementations, voters should determine whether the returned price differs from broad market consensus. This is meant to provide flexibility in any unforeseen circumstances as voters are responsible for defining broad market consensus.
 


### PR DESCRIPTION
This PR updates the unused GASETH-TWAP-1Mx1M price id to allow it to be used again for future contracts. Other than small nit corrections, only the used timestamp is changed.