### PR TITLE
Add BCHDOM, BNBDOM, BSVDOM, DOTDOM, ETHDOM, LINKDOM, LTCDOM, USDTDOM & XRPDOM as price identifiers

### DIFF
--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -10,47 +10,54 @@
 <br>
 
 # SUMMARY 
-The DVM should support price requests for the relative market capitalization indices of these top 9 cryptocurrencies (according to CoinGecko). These indices are commonly known as *"dominance"* indices.
+The DVM should support price requests for the relative market capitalization indices of these top 9 cryptocurrencies (according to CoinGecko). These indices are commonly known as *"dominance"* indices. Compared to other typical UMIP price identifiers, these indices are *unit-less* since they are simply a percentage represented as a whole number.
+
+Each price identifier for a particular cryptocurrency's market share in general is calculated by taking,
+ * the total *circulating* supply of that cryptocurrency,
+ * multiplied by the current price of the token in USD,
+ * divided by the global market cap of all cryptocurrencies.
 
 The price identifiers are constructed using the following formulations below.
 
-> Note: The actual price identifier values are whole numbers out of 100. For example, a value of 12.34% is represented as the value
+> **REMARK**&emsp; The formulas shown below gives the reader a general concept of how one arrives at the prices of these indices. In general, there can be significant deviations and methodology as to how data providers actually calculate coin dominance. Calculating global cryptocurrency market cap involves curating 5000+ coins, in CoinGecko's case, as querying live USD prices and outstanding supply of each of those coins on the market -- as well as providing accessible API access. We give a more long form explanation in "Rationale".
+
+> **REMARK**&emsp; The actual price identifier values are whole numbers out of 100. For example, a value of 12.34% is represented as the value
 > raw decimal value of `12.34`. Therefore, all price identifier values for dominance indices will always be within the range `0.00 <= x < 100.00`, for some dominance index value `x`.
 
 ```
-BCHDOM →    [Total BCH supply]
+BCHDOM →    [Total BCH circulating supply]
           * [Price of BCHUSD]
           / [Total crypto market cap (USD)]
 
-BNBDOM →    [Total BNB supply]
+BNBDOM →    [Total BNB circulating supply]
           * [Price of BNBUSD]
           / [Total crypto market cap (USD)]
 
-BSVDOM →    [Total BSV supply]
+BSVDOM →    [Total BSV circulating supply]
           * [Price of BSVUSD]
           / [Total crypto market cap (USD)]
 
-DOTDOM →    [Total DOT supply]
+DOTDOM →    [Total DOT circulating supply]
           * [Price of DOTUSD]
           / [Total crypto market cap (USD)]
 
-ETHDOM →    [Total ETH supply]
+ETHDOM →    [Total ETH circulating supply]
           * [Price of ETHUSD]
           / [Total crypto market cap (USD)]
 
-LINKDOM →   [Total LINK supply]
+LINKDOM →   [Total LINK circulating supply]
           * [Price of LINKUSD]
           / [Total crypto market cap (USD)]
 
-LTCDOM →    [Total LTC supply]
+LTCDOM →    [Total LTC circulating supply]
           * [Price of LTCUSD]
           / [Total crypto market cap (USD)]
 
-USDTDOM →   [Total USDT supply]
+USDTDOM →   [Total USDT circulating supply]
           * [Price of USDTUSD]
           / [Total crypto market cap (USD)]
 
-XRPDOM →    [Total XRP supply]
+XRPDOM →    [Total XRP circulating supply]
           * [Price of XRPUSD]
           / [Total crypto market cap (USD)]
 ```
@@ -226,8 +233,7 @@ The repository is available at: https://github.com/ferrosync/coingecko-cache
 
 **4. Rounding**
 
-> **Note:**  
-> The price identifier values are represented as whole numbers between `0.00` and `100.00`, inclusive. For example, a market dominance of 12.34% is represented as the value
+> **REMARK**&emsp;The price identifier values are represented as whole numbers between `0.00` and `100.00`, inclusive. For example, a market dominance of 12.34% is represented as the value
 > raw decimal value of `12.34` and will be represented on-chain as the raw value `12340000000000000000`.  
 > Appropriate scaling on-chain to 18 decimal places to "convert to wei" is applied as usual.
 
@@ -259,7 +265,7 @@ Initially, during normal operation, market dominance indices should closely trac
 
 2. **Pricing interval**
 
-    - 1 min
+    - 1 min (round down relative to UTC)
 
 3. **Input processing**
 

--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -114,7 +114,7 @@ The data source used for these indicies is provided by CoinGecko as a reliable a
 
 # PRICE FEED IMPLEMENTATION
 
-An existing implementation of a price feed using the `api.domination.finance` endpoint is already implemented. Additional feeds will need to be enabled for the 9 price identifiers that are specified in this UMIP. The associated endpoints for these price identifiers are below.
+An existing implementation of a price feed using the `api.domination.finance` endpoint is already implemented. Additional feeds will need to be enabled for the 9 price identifiers that are specified in this UMIP. The associated endpoints for these price identifiers are below. See the section that follows ("Price Feed Sources") that further explains the backing data source of this price feeds.
 
 BNB:
  * https://api.domination.finance/api/v0/price/bnbdom
@@ -152,6 +152,51 @@ XRP:
  * https://api.domination.finance/api/v0/price/xrpdom
  * https://api.domination.finance/api/v0/price/xrpdom/history
 
+
+## Price Feed Sources
+
+### CoinGecko Live API
+
+The CoinGecko live coin domination feed API is available at the following URL:
+
+```
+https://api.coingecko.com/api/v3/global/coin_dominance
+```
+
+> Note that the `api.domination.finance` endpoints directly derive from this CoinGecko endpoint. For example, these endpoints will pull the latest snapshot from the CoinGecko endpoint:
+> ```
+> https://api.domination.finance/api/v0/coingecko/coin_dominance
+> https://api.domination.finance/api/v0/price/{XYZ}dom
+> ```
+
+The response data uses the following JSON format:
+```
+[
+  "data": [{
+    "name": "BTC",
+    "id": "bitcoin",
+    "market_cap_usd": 287767856413.73145,
+    "dominance_percentage": 63.38458529247809
+  }],
+  "timestamp": 1605329724
+  ...
+]
+```
+
+Each coin whose market dominance is tracked is reported as an element within a JSON array, 
+ - `data` - an array of cryptocurrencies
+   - `name` - giving the colloquial ticker symbol,
+   - `id` - CoinGecko’s unique identifier for the coin,
+   - `market_cap_usd` - the total market capitalization in USD,
+   - `dominance_percentage` - the market dominance percentage as a decimal number from 0 to 100
+ - `timestamp` - the Unix timestamp when this data was generated from CoinGecko
+ 
+### Historical Data API
+Dispute bots and voters will need to query the cached historical data, dating back 74 hours. CoinGecko solely provides live data in minutely intervals, hence a custom solution was needed to ensure accurate historical data for a sufficient enough time frame.
+
+A reference implementation for a historical data caching solution is open-source and dual-licensed under MIT and Apache 2.0 to allow any stakeholder to host their own copy as well as provide a reference for any stakeholder who wishes to implement their own.
+
+The repository is available at: https://github.com/ferrosync/coingecko-cache
 
 <br>
 
@@ -210,7 +255,7 @@ Initially, during normal operation, market dominance indices should closely trac
 
 1. **What prices should be queried for and from which markets?**
 
-    - The applicable price market dominance index should be queried dependeing on the
+    - The applicable price market dominance index should be queried depending on the cryptocurrency of interest.
 
 2. **Pricing interval**
 

--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -10,8 +10,12 @@
 <br>
 
 # SUMMARY 
-The DVM should support price requests for the following dominance indices.
-The price identifiers can be defined as:
+The DVM should support price requests for the relative market capitalization indices of these top 9 cryptocurrencies (according to CoinGecko). These indices are commonly known as *"dominance"* indices.
+
+The price identifiers are constructed using the following formulations below.
+
+> Note: The actual price identifier values are whole numbers out of 100. For example, a value of 12.34% is represented as the value
+> raw decimal value of `12.34`. Therefore, all price identifier values for dominance indices will always be within the range `0.00 <= x < 100.00`, for some dominance index value `x`.
 
 ```
 BCHDOM →    [Total BCH supply]
@@ -34,7 +38,7 @@ ETHDOM →    [Total ETH supply]
           * [Price of ETHUSD]
           / [Total crypto market cap (USD)]
 
-LINKDOM →    [Total LINK supply]
+LINKDOM →   [Total LINK supply]
           * [Price of LINKUSD]
           / [Total crypto market cap (USD)]
 
@@ -42,7 +46,7 @@ LTCDOM →    [Total LTC supply]
           * [Price of LTCUSD]
           / [Total crypto market cap (USD)]
 
-USDTDOM →    [Total USDT supply]
+USDTDOM →   [Total USDT supply]
           * [Price of USDTUSD]
           / [Total crypto market cap (USD)]
 
@@ -53,19 +57,21 @@ XRPDOM →    [Total XRP supply]
 
 # MOTIVATION
 
-This section should clearly explain the types of financial products that will be created and the mechanics of an example financial product using this price identifier. Please answer the following questions:
+The DVM currently does not support the listed dominance indices. Synthetic tokens which track market dominance could be used as hedging tools in one’s portfolio. These synthetic tokens can also be used as tools to speculate on a cryptocurrency's market share relative to all other cryptocurrencies.
 
 1. What are the financial positions enabled by creating this synthetic that do not already exist?
 
-    - [ANSWER]
+    - These synthetic tokens will enable users to enter into financial positions based on a particular coins market dominance. Previously, our team created an instrument on UMA to be able take positions on the,
+      - (i) relative market cap of Bitcoin (BTCDOM), as well as,
+      - (ii) all alt-coins against Bitcoin (ALTDOM).
+    - These new price identifiers allow users to take positions to long or short the relative market cap of these top 9 crypocurrencies.
+    - More importantly, not all these underlying cryptocurrencies are available to be traded on Ethereum.
 
 2. Please provide an example of a person interacting with a contract that uses this price identifier. 
 
-    - Remember, price identifiers **return the units of the collateral currency**. 
+    > TODO: This example is backwards! It should be DAI/LTCDOM
 
-         - For example, if at expiry the price id returns 1 and the contract is collateralized in renBTC, each synth would be worth 1 renBTC.
-
-    - [ANSWER]
+    - A user happens to be bearish on the relative market capitalization of Litecoin (LTC). Assume there is a LTCDOM/DAI synthetic EMP with a 150% GCR. If LTC dominance is at 0.77%, the a price identifier will have an index price of 0.77 LTCDOM/DAI (or ~1.2987 DAI/LTCDOM). They put up 100 DAI as collateral to mint ~86.58 LTCDOM synthetic tokens. They then sell the 86.58 LTCDOM tokens on the market for ~66.66 DAI in exchange. Say the index price drops to 0.51% and the user wishes to close their position. They buy back 86.58 LTCDOM tokens at a market price of 0.51 LTCDOM/DAI (or ~1.9608 DAI/LTCDOM), receiving 
 
 3. Consider adding market data  (e.g., if we add a “Dai alternative,” the author could show the market size of Dai)
 

--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -1,0 +1,252 @@
+## HEADERS
+| UMIP [#]   | |
+|------------|------------|
+| UMIP Title | Add BCHDOM, BNBDOM, BSVDOM, DOTDOM, ETHDOM, LINKDOM, LTCDOM, USDTDOM & XRPDOM as a price identifiers |
+| Authors    | Domination Finance (Josh Bowden <josh@ferrosync.io>, Michal Cymbalisty <michal@domination.finance>, et. al.)
+| Status     | Draft |
+| Created    | March 16, 2021 |
+| Link to Discourse    | [LINK] |
+<br>
+<br>
+
+# SUMMARY 
+The DVM should support price requests for the following dominance indices.
+The price identifiers can be defined as:
+
+```
+BCHDOM →    [Total BCH supply]
+          * [Price of BCHUSD]
+          / [Total crypto market cap (USD)]
+
+BNBDOM →    [Total BNB supply]
+          * [Price of BNBUSD]
+          / [Total crypto market cap (USD)]
+
+BSVDOM →    [Total BSV supply]
+          * [Price of BSVUSD]
+          / [Total crypto market cap (USD)]
+
+DOTDOM →    [Total DOT supply]
+          * [Price of DOTUSD]
+          / [Total crypto market cap (USD)]
+
+ETHDOM →    [Total ETH supply]
+          * [Price of ETHUSD]
+          / [Total crypto market cap (USD)]
+
+LINKDOM →    [Total LINK supply]
+          * [Price of LINKUSD]
+          / [Total crypto market cap (USD)]
+
+LTCDOM →    [Total LTC supply]
+          * [Price of LTCUSD]
+          / [Total crypto market cap (USD)]
+
+USDTDOM →    [Total USDT supply]
+          * [Price of USDTUSD]
+          / [Total crypto market cap (USD)]
+
+XRPDOM →    [Total XRP supply]
+          * [Price of XRPUSD]
+          / [Total crypto market cap (USD)]
+```
+
+# MOTIVATION
+
+This section should clearly explain the types of financial products that will be created and the mechanics of an example financial product using this price identifier. Please answer the following questions:
+
+1. What are the financial positions enabled by creating this synthetic that do not already exist?
+
+    - [ANSWER]
+
+2. Please provide an example of a person interacting with a contract that uses this price identifier. 
+
+    - Remember, price identifiers **return the units of the collateral currency**. 
+
+         - For example, if at expiry the price id returns 1 and the contract is collateralized in renBTC, each synth would be worth 1 renBTC.
+
+    - [ANSWER]
+
+3. Consider adding market data  (e.g., if we add a “Dai alternative,” the author could show the market size of Dai)
+
+<br> 
+
+# MARKETS & DATA SOURCES
+
+ **Required questions**
+
+1. What markets should the price be queried from? It is recommended to have at least 3 markets.
+
+    - [ANSWER]
+
+2.  Which specific pairs should be queried from each market?
+
+    - [ANSWER]
+
+2. Provide recommended endpoints to query for real-time prices from each market listed. 
+
+    - These should match the data sources used in  "Price Feed Implementation". 
+
+    - [ADD-ENDPOINTS]
+    
+4. How often is the provided price updated?
+
+    - [ANSWER]
+
+5. Provide recommended endpoints to query for historical prices from each market listed. 
+
+    - [ADD-ENDPOINTS]
+
+6.  Do these sources allow for querying up to 74 hours of historical data? 
+
+    - [ANSWER]
+
+7.  How often is the provided price updated?
+
+    - [ANSWER]
+
+8. Is an API key required to query these sources? 
+
+    - [ANSWER]
+
+9. Is there a cost associated with usage? 
+
+    - [ANSWER]
+
+10. If there is a free tier available, how many queries does it allow for?
+
+    - [ANSWER]
+
+11.  What would be the cost of sending 15,000 queries?
+
+     - [ANSWER]
+
+<br>
+
+# PRICE FEED IMPLEMENTATION
+
+To allow for the creation of bots that can programmatically calculate prices off-chain to liquidate and dispute transactions, you must create a price feed following the UMA Protocol format (outlined below). This price feed is also necessary to calculate developer mining rewards.
+
+To meet this criteria, please include a link to a PR to the UMA [protocol repo](https://github.com/UMAprotocol/protocol) with an example price feed that inherits this [PriceFeedInterface](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js). 
+
+Classes of price identifiers that are supported by default and require no additional price feed include.
+
+- Any currency pair available on [Cryptowatch](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js)
+
+- [Uniswap prices](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js)
+
+- [Balancer prices](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js)
+
+Please provide a link to your price feed pull request.
+
+- [ADD-LINK-TO-PULL-REQUEST]
+
+<br>
+
+# TECHNICAL SPECIFICATIONS
+
+**1. Price Identifier Name** - [ADD NAME]
+
+**2. Base Currency** - [ADD BASE CURRENCY]
+
+**3. Quote currency** - [ADD QUOTE CURRENCY]
+
+- If your price identifier is a currency pair, your quote currency will be the
+denominator of your currency pair. If your price identifier does not have a quote currency, please explain the reasoning behind this.
+
+- Please be aware that the value of any UMA synthetic token is the value of the price identifier in units of the collateral currency used. If a contract’s price identifier returns 1, and is collateralized in renBTC, each synthetic will be worth 1 renBTC. In most cases, the value of your quote currency and intended collateral currency should be equal.
+
+- [Response - if applicable]
+
+**4. Intended Collateral Currency** - [ADD COLLATERAL CURRENCY]
+
+- Does the value of this collateral currency match the standalone value of the listed quote currency? 
+
+    - [ANSWER]
+
+- Is your collateral currency already approved to be used by UMA financial contracts? If no, submit a UMIP to have the desired collateral currency approved for use. 
+
+    - View [here](https://docs.umaproject.org/uma-tokenholders/approved-collateral-currencies) to see a list of approved collateral currencies. 
+
+    - [ANSWER]
+
+**5. Collateral Decimals** - [ADD DECIMALS]
+
+- Price identifiers need to be automatically scaled to reflect the units of collateral that a price represents. Because of this, the amount of decimals that a price is scaled to needs to match the used collateral currency. 
+
+- **Example**
+
+    - USDC has 6 Decimals (obtained [here](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)). 
+
+**6. Rounding** - [ADD ROUNDING]
+
+- **Note** - this should always be less than or equal to the `Intended Collateral Currency` field.
+
+- **Example** 
+
+    - Round to 3 decimal places. 
+
+    - If the price is .0235, then this would be rounded up to .024. If the price is .02349, then this would be rounded down to .023. 
+
+<br>
+
+# RATIONALE
+
+The rationale should flesh out the specification by describing what motivated the design and why particular design decisions were made, as well as any alternative designs that were considered.
+
+- [RESPONSE]
+
+**Example questions**
+
+- Why this implementation of the identifier as opposed to other implementation designs?
+
+- What analysis can you provide on where to get the most robust prices? (Robust as in legitimate liquidity, legitimate volume, price discrepancies between exchanges, and trading volume between exchanges)
+
+- What is the potential for the price to be manipulated on the chosen exchanges?
+
+- Should the prices have any processing (e.g., TWAP)? 
+
+    - If so, why was this processing method chosen?
+
+<br>
+
+# IMPLEMENTATION
+
+Describe how UMA tokenholders should arrive at the price in the case of a DVM price request? Document each step a voter should take to query for and return a price at a specific timestamp. This should include a waterfall of if-then statements (e.g., if a certain exchange is not available, then proceed in a different way). Include the following in the description:
+
+
+1. **What prices should be queried for and from which markets?**
+
+    - **Note** - This should match the markets and pairs listed in the `Markets and Data Sources` section.  
+
+    - [ANSWER]
+
+2. **Pricing interval**
+
+    - [ANSWER]
+
+3. **Input processing**
+
+    - [ANSWER]
+
+4. **Result processing** 
+
+    - **Note** - a result processing of "median" is more resilient to market manipulation versus a result processing of "average"
+
+     - [ANSWER]
+
+<br>
+
+# Security considerations
+
+**Example questions**
+
+1. Where could manipulation occur?
+
+2. How could this price ID be exploited?
+
+3. Do the instructions for determining the price provide people with enough certainty?
+
+4. What are current or future concern possibilities with the way the price identifier is defined?
+
+5. Are there any concerns around if the price identifier implementation is deterministic?

--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -1,7 +1,7 @@
 ## HEADERS
 | UMIP [#]   | |
 |------------|------------|
-| UMIP Title | Add BCHDOM, BNBDOM, BSVDOM, DOTDOM, ETHDOM, LINKDOM, LTCDOM, USDTDOM & XRPDOM as a price identifiers |
+| UMIP Title | Add BCHDOM, BNBDOM, BSVDOM, DOTDOM, ETHDOM, LINKDOM, LTCDOM, USDTDOM & XRPDOM as price identifiers |
 | Authors    | Domination Finance (Josh Bowden (<josh@ferrosync.io>), Michal Cymbalisty (<michal@domination.finance>), et. al.)
 | Status     | Draft |
 | Created    | March 16, 2021 |

--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -5,7 +5,7 @@
 | Authors    | Domination Finance (Josh Bowden (<josh@ferrosync.io>), Michal Cymbalisty (<michal@domination.finance>), et. al.)
 | Status     | Draft |
 | Created    | March 16, 2021 |
-| Link to Discourse | https://discourse.umaproject.org/t/add-bchdom-bnbdom-bsvdom-dotdom-ethdom-linkdom-ltcdom-usdtdom-xrpdom-as-a-price-identifiers/346 |
+| Link to Discourse | https://discourse.umaproject.org/t/add-bchdom-bnbdom-bsvdom-dotdom-ethdom-linkdom-ltcdom-usdtdom-xrpdom-as-price-identifiers/346 |
 <br>
 <br>
 

--- a/UMIPs/umip-draft_domfi_alts.md
+++ b/UMIPs/umip-draft_domfi_alts.md
@@ -2,10 +2,10 @@
 | UMIP [#]   | |
 |------------|------------|
 | UMIP Title | Add BCHDOM, BNBDOM, BSVDOM, DOTDOM, ETHDOM, LINKDOM, LTCDOM, USDTDOM & XRPDOM as a price identifiers |
-| Authors    | Domination Finance (Josh Bowden <josh@ferrosync.io>, Michal Cymbalisty <michal@domination.finance>, et. al.)
+| Authors    | Domination Finance (Josh Bowden (<josh@ferrosync.io>), Michal Cymbalisty (<michal@domination.finance>), et. al.)
 | Status     | Draft |
 | Created    | March 16, 2021 |
-| Link to Discourse    | [LINK] |
+| Link to Discourse | https://discourse.umaproject.org/t/add-bchdom-bnbdom-bsvdom-dotdom-ethdom-linkdom-ltcdom-usdtdom-xrpdom-as-a-price-identifiers/346 |
 <br>
 <br>
 
@@ -69,190 +69,169 @@ The DVM currently does not support the listed dominance indices. Synthetic token
 
 2. Please provide an example of a person interacting with a contract that uses this price identifier. 
 
-    > TODO: This example is backwards! It should be DAI/LTCDOM
-
-    - A user happens to be bearish on the relative market capitalization of Litecoin (LTC). Assume there is a LTCDOM/DAI synthetic EMP with a 150% GCR. If LTC dominance is at 0.77%, the a price identifier will have an index price of 0.77 LTCDOM/DAI (or ~1.2987 DAI/LTCDOM). They put up 100 DAI as collateral to mint ~86.58 LTCDOM synthetic tokens. They then sell the 86.58 LTCDOM tokens on the market for ~66.66 DAI in exchange. Say the index price drops to 0.51% and the user wishes to close their position. They buy back 86.58 LTCDOM tokens at a market price of 0.51 LTCDOM/DAI (or ~1.9608 DAI/LTCDOM), receiving 
-
-3. Consider adding market data  (e.g., if we add a “Dai alternative,” the author could show the market size of Dai)
+    - A user wanting to short a particular cryptocurrency's market dominance can mint synthetics and then market sell them.
+    - A user wanting to long a particular cryptocurrency's market dominance can market buy a synthetic token.
 
 <br> 
 
 # MARKETS & DATA SOURCES
 
- **Required questions**
+The data source used for these indicies is provided by CoinGecko as a reliable and actively maintained source for coin market dominance. Additional clarification is providing in *Rationale*.
 
-1. What markets should the price be queried from? It is recommended to have at least 3 markets.
+1. Provide recommended endpoints to query for real-time prices from each market listed. 
 
-    - [ANSWER]
-
-2.  Which specific pairs should be queried from each market?
-
-    - [ANSWER]
-
-2. Provide recommended endpoints to query for real-time prices from each market listed. 
-
-    - These should match the data sources used in  "Price Feed Implementation". 
-
-    - [ADD-ENDPOINTS]
+    - See endpoints listed in *Price Feed Implementation*
     
-4. How often is the provided price updated?
+2. How often is the provided price updated?
 
-    - [ANSWER]
+    - 1 min
 
-5. Provide recommended endpoints to query for historical prices from each market listed. 
+3. Provide recommended endpoints to query for historical prices from each market listed. 
 
-    - [ADD-ENDPOINTS]
+    - See endpoints listed in *Price Feed Implementation*
 
-6.  Do these sources allow for querying up to 74 hours of historical data? 
+4.  Do these sources allow for querying up to 74 hours of historical data? 
 
-    - [ANSWER]
+    - Yes
 
-7.  How often is the provided price updated?
+5. Is an API key required to query these sources? 
 
-    - [ANSWER]
+    - No
 
-8. Is an API key required to query these sources? 
+6. Is there a cost associated with usage? 
 
-    - [ANSWER]
+    - No
 
-9. Is there a cost associated with usage? 
+7.  If there is a free tier available, how many queries does it allow for?
 
-    - [ANSWER]
+    - N/A, access is free but rate limited to no more than 1 query/sec
 
-10. If there is a free tier available, how many queries does it allow for?
+8.   What would be the cost of sending 15,000 queries?
 
-    - [ANSWER]
-
-11.  What would be the cost of sending 15,000 queries?
-
-     - [ANSWER]
+     - $0
 
 <br>
 
 # PRICE FEED IMPLEMENTATION
 
-To allow for the creation of bots that can programmatically calculate prices off-chain to liquidate and dispute transactions, you must create a price feed following the UMA Protocol format (outlined below). This price feed is also necessary to calculate developer mining rewards.
+An existing implementation of a price feed using the `api.domination.finance` endpoint is already implemented. Additional feeds will need to be enabled for the 9 price identifiers that are specified in this UMIP. The associated endpoints for these price identifiers are below.
 
-To meet this criteria, please include a link to a PR to the UMA [protocol repo](https://github.com/UMAprotocol/protocol) with an example price feed that inherits this [PriceFeedInterface](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/PriceFeedInterface.js). 
+BNB:
+ * https://api.domination.finance/api/v0/price/bnbdom
+ * https://api.domination.finance/api/v0/price/bnbdom/history
 
-Classes of price identifiers that are supported by default and require no additional price feed include.
+BCH:
+ * https://api.domination.finance/api/v0/price/bchdom
+ * https://api.domination.finance/api/v0/price/bchdom/history
 
-- Any currency pair available on [Cryptowatch](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/CryptoWatchPriceFeed.js)
+BSV:
+ * https://api.domination.finance/api/v0/price/bsvdom
+ * https://api.domination.finance/api/v0/price/bsvdom/history
 
-- [Uniswap prices](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/UniswapPriceFeed.js)
+DOT:
+ * https://api.domination.finance/api/v0/price/dotdom
+ * https://api.domination.finance/api/v0/price/dotdom/history
 
-- [Balancer prices](https://github.com/UMAprotocol/protocol/blob/master/packages/financial-templates-lib/src/price-feed/BalancerPriceFeed.js)
+ETH:
+ * https://api.domination.finance/api/v0/price/ethdom
+ * https://api.domination.finance/api/v0/price/ethdom/history
 
-Please provide a link to your price feed pull request.
+LINK:
+ * https://api.domination.finance/api/v0/price/linkdom
+ * https://api.domination.finance/api/v0/price/linkdom/history
 
-- [ADD-LINK-TO-PULL-REQUEST]
+LTC:
+ * https://api.domination.finance/api/v0/price/ltcdom
+ * https://api.domination.finance/api/v0/price/ltcdom/history
+
+USDT:
+ * https://api.domination.finance/api/v0/price/usdtdom
+ * https://api.domination.finance/api/v0/price/usdtdom/history
+
+XRP:
+ * https://api.domination.finance/api/v0/price/xrpdom
+ * https://api.domination.finance/api/v0/price/xrpdom/history
+
 
 <br>
 
 # TECHNICAL SPECIFICATIONS
 
-**1. Price Identifier Name** - [ADD NAME]
+**1. Price Identifier Names**
+    
+ - `BCHDOM`
+ - `BNBDOM`
+ - `BSVDOM`
+ - `DOTDOM`
+ - `ETHDOM`
+ - `LINKDOM`
+ - `LTCDOM`
+ - `USDTDOM`
+ - `XRPDOM`
 
-**2. Base Currency** - [ADD BASE CURRENCY]
+> Since all the market dominance price identifiers are indices based off of a raw percentage, there is no inherent base or quote currency involved.
 
-**3. Quote currency** - [ADD QUOTE CURRENCY]
+**2. Intended Collateral Currency** - DAI
 
-- If your price identifier is a currency pair, your quote currency will be the
-denominator of your currency pair. If your price identifier does not have a quote currency, please explain the reasoning behind this.
+- Is your collateral currency already approved to be used by UMA financial contracts?
 
-- Please be aware that the value of any UMA synthetic token is the value of the price identifier in units of the collateral currency used. If a contract’s price identifier returns 1, and is collateralized in renBTC, each synthetic will be worth 1 renBTC. In most cases, the value of your quote currency and intended collateral currency should be equal.
+    - Yes
 
-- [Response - if applicable]
+**3. Scaling Decimals** - 18
 
-**4. Intended Collateral Currency** - [ADD COLLATERAL CURRENCY]
+**4. Rounding**
 
-- Does the value of this collateral currency match the standalone value of the listed quote currency? 
+> **Note:**  
+> The price identifier values are represented as whole numbers between `0.00` and `100.00`, inclusive. For example, a market dominance of 12.34% is represented as the value
+> raw decimal value of `12.34` and will be represented on-chain as the raw value `12340000000000000000`.  
+> Appropriate scaling on-chain to 18 decimal places to "convert to wei" is applied as usual.
 
-    - [ANSWER]
-
-- Is your collateral currency already approved to be used by UMA financial contracts? If no, submit a UMIP to have the desired collateral currency approved for use. 
-
-    - View [here](https://docs.umaproject.org/uma-tokenholders/approved-collateral-currencies) to see a list of approved collateral currencies. 
-
-    - [ANSWER]
-
-**5. Collateral Decimals** - [ADD DECIMALS]
-
-- Price identifiers need to be automatically scaled to reflect the units of collateral that a price represents. Because of this, the amount of decimals that a price is scaled to needs to match the used collateral currency. 
-
-- **Example**
-
-    - USDC has 6 Decimals (obtained [here](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48)). 
-
-**6. Rounding** - [ADD ROUNDING]
-
-- **Note** - this should always be less than or equal to the `Intended Collateral Currency` field.
-
-- **Example** 
-
-    - Round to 3 decimal places. 
-
-    - If the price is .0235, then this would be rounded up to .024. If the price is .02349, then this would be rounded down to .023. 
+ - The index value is rounded to nearest 2 decimal places (third decimal place digit >= 5 rounds up and < 5 rounds down)
 
 <br>
 
 # RATIONALE
 
-The rationale should flesh out the specification by describing what motivated the design and why particular design decisions were made, as well as any alternative designs that were considered.
+Prices are primarily used in UMA to calculate a synthetic token’s value in case of liquidation or expiration. Contract counterparties, such as those running liquidation bots, also use the price index to ensure that sponsors are adequately collateralized.
 
-- [RESPONSE]
+While coin domination can be succinctly represented as a single percentage, the underlying mechanisms for calculating it are quite involved and can dramatically differ by multiple percentage points from one data source to another. Calculating dominance involves knowing the current supply of a cryptocurrency, the prevailing market price of CRYPTOCURRENCY/USD, and the total market capitalization of all tokens in USD. More importantly, calculating the total market capitalization of all tokens in USD is a challenge since different data sources may altogether not include particular alt-coins thereby affecting all coin market dominance percentages.
 
-**Example questions**
+At the moment, market dominance is commonly referenced through three major sources: TradingView, CoinMarketCap & CoinGecko. However, unlike trading pairs which exhibit strong redundancy without deviation largely due to arbitrage incentives, each data source can vary by multiple percentage points due to differing calculation methodologies. Namely, each site has different methodologies for which alt-coins to admit into the total market cap, and a given coin’s market price and total coin circulation amounts may differ, compounding over hundreds or even thousands of alt-coins. Additionally, on a technical note, live and historical data update frequency varies and historical data may be paywalled, making it significantly harder to successfully run liquidation and dispute bots with redundancy and without paying for API access. To make matters worse, had we proposed a scheme where multiple data sources were used, we’d have to decide on using either the median or mean of the data sources and then have to specify some logic to handle if one of the data sources went down or starting to significantly different from the rest, for example.
 
-- Why this implementation of the identifier as opposed to other implementation designs?
+In an effort to alleviate these challenges, the Domination Finance team was able to get in touch with Bobby & TM, the co-founders of CoinGecko. The CoinGecko team went above and beyond to meet the requisites, updating CoinGecko’s coin dominance live data to 1-3 minute intervals from what was previously 10 minutes. Although this may introduce a single point of failure, we felt that the costs in increased complexity and mental load on the stakeholders who need to use it (like speculators, sponsors, liquidators & disputers) outweighed the benefits, especially during this period where the synthetic token is newly launched.
 
-- What analysis can you provide on where to get the most robust prices? (Robust as in legitimate liquidity, legitimate volume, price discrepancies between exchanges, and trading volume between exchanges)
+While CoinGecko was able to provide the higher time granularity for coin dominance on short notice, historical data, necessary for dispute bots and voters, was unable to be immediately supplied from CoinGecko. Instead, constructing a separate caching service was necessary to track and record the historical data via polling CoinGecko's Live API to be able to compute historical coin dominance at a given point in time. Our caching API is more than sufficient to provide the historical data for dispute bots and voters.
 
-- What is the potential for the price to be manipulated on the chosen exchanges?
-
-- Should the prices have any processing (e.g., TWAP)? 
-
-    - If so, why was this processing method chosen?
+Initially, during normal operation, market dominance indices should closely track the value on CoinGecko. As more data sources for market dominance data are created and examined, voters are encouraged to add additional sources of information into the methodology for the price calculation.
 
 <br>
 
 # IMPLEMENTATION
 
-Describe how UMA tokenholders should arrive at the price in the case of a DVM price request? Document each step a voter should take to query for and return a price at a specific timestamp. This should include a waterfall of if-then statements (e.g., if a certain exchange is not available, then proceed in a different way). Include the following in the description:
-
-
 1. **What prices should be queried for and from which markets?**
 
-    - **Note** - This should match the markets and pairs listed in the `Markets and Data Sources` section.  
-
-    - [ANSWER]
+    - The applicable price market dominance index should be queried dependeing on the
 
 2. **Pricing interval**
 
-    - [ANSWER]
+    - 1 min
 
 3. **Input processing**
 
-    - [ANSWER]
+    - None.
 
 4. **Result processing** 
 
-    - **Note** - a result processing of "median" is more resilient to market manipulation versus a result processing of "average"
-
-     - [ANSWER]
+    - See rounding rules in *Technical Specification*.
 
 <br>
 
 # Security considerations
 
-**Example questions**
+The current implementation relies on CoinGecko's and the Domination Finance's API endpoints to be able to receive accurate pricing information. Since calculating market dominance is an involved process with a number of variables at play, the trade-off is made to have a stable formulation from a single source instead of multiple sources which have widely varying calculation methodologies and public data availability.
 
-1. Where could manipulation occur?
+In the unlikely event that market index values returned from data sources are extreme outliers or erroneous compared to current market consensus, $UMA-holders may choose to use prevailing market consensus or using a nearby timestamp value instead.
 
-2. How could this price ID be exploited?
+Anyone deploying a new priceless token contract referencing these identifiers should take care to parameterize the contract appropriately to avoid the loss of funds for synthetic token holders. Additionally, the contract deployer should ensure that there is a network of liquidators and disputers ready to perform the services necessary to keep the contract solvent.
 
-3. Do the instructions for determining the price provide people with enough certainty?
-
-4. What are current or future concern possibilities with the way the price identifier is defined?
-
-5. Are there any concerns around if the price identifier implementation is deterministic?
+$UMA-holders should evaluate the ongoing cost and benefit of supporting price requests for these identifiers and also contemplate de-registering these identifiers if security holes are identified. As noted above, $UMA-holders should also consider re-defining this identifier as liquidity in the underlying asset changes, or if added robustness is necessary to prevent market manipulation.


### PR DESCRIPTION
Hey all,

This UMIP proposal adds 9 additional market dominance price identifiers that are currently supported by CoinGecko.
Let us know your feedback or any questions you have regarding the UMIP.

Thanks!
~ Domination Finance Team