### PR TITLE
Update USDETH rounding spec to 8 decimals based on community feedback

### DIFF
--- a/UMIPs/umip-6.md
+++ b/UMIPs/umip-6.md
@@ -34,7 +34,7 @@ The definition of these identifiers should be:
 
 - Exchanges: Binance, Coinbase, Kraken
 - Input Processing: None. Human intervention in extreme circumstances where the result differs from broad market consensus.
-- Price Steps: 0.00001 (5 decimals in more general trading format)
+- Price Steps: 0.00000001 (8 decimals in more general trading format)
 - Rounding: Closest, 0.5 up
 - Pricing Interval: 60 seconds
 - Dispute timestamp rounding: down


### PR DESCRIPTION
Updating the USDETH price identifier to round to more decimal places has been discussed multiple times during voting. This PR makes that change.

Couple of examples of discussions and consensus around this change:
- [Discussion 1](https://discord.com/channels/718590743446290492/719352532354465833/845293636961697912)
- [Discussion 2](https://discord.com/channels/718590743446290492/719352532354465833/827211957571420191)