### PR TITLE
Fix to straight quotation marks

### DIFF
--- a/Implementations/bankless-legal-guild.md
+++ b/Implementations/bankless-legal-guild.md
@@ -13,8 +13,8 @@ Using KPI options creates a structure where each contributor to the project is i
 ## Intended Ancillary Data
 
 Metric:Completion percentage of Bankless DAO Legal Guild's project to legally assess the BANK token as determined by the Guild,
-Endpoint:”https://docs.google.com/spreadsheets/d/1jkRO91ACGFCwhwVQsXKtnAt1Nz2qSdkNg9XYJdgbmYs/edit?usp=sharing”,
-Method:”https://github.com/UMAprotocol/UMIPs/blob/master/Implementations/bankless-legal-guild.md",
+Endpoint:"https://docs.google.com/spreadsheets/d/1jkRO91ACGFCwhwVQsXKtnAt1Nz2qSdkNg9XYJdgbmYs/edit?usp=sharing",
+Method:"https://github.com/UMAprotocol/UMIPs/blob/master/Implementations/bankless-legal-guild.md",
 Key:Total Section Completion Percentage,
 Interval:weekly,
 Rounding:4,


### PR DESCRIPTION
Signed-off-by: Reinis Martinsons <reinis@umaproject.org>

In order not to over-complicate the ancillary data parsing module better to use just straight quotation marks for escaping values with delimiters (: or ,) 