### PR TITLE
Add DFX Polygon token

### DIFF
--- a/Add DFX Polygon.md
+++ b/Add DFX Polygon.md
@@ -1,0 +1,40 @@
+**UMIP #**  - tbd
+
+-   **UMIP title:** Add **DFX** as a Polygon collateral currency 
+-   **Author**  Chandler (chandler@umaproject.org)
+-   **Status: Draft**
+-   **Created:**  10 September 2021
+
+## Summary (2-5 sentences)
+
+This UMIP proposes adding **DFX** for use as collateral in UMA contracts for the Polygon Network. DFX has already been approved for use as collateral on Ethereum.
+
+## Motivation
+
+The addition of this collateral currency offers additional functionality to the UMA protocol and increases the range of contracts that can be built.
+
+## Technical Specification
+
+To accomplish this upgrade, the following changes need to be made:
+
+- The DFX [Polygon token](https://polygonscan.com/address/0xe7804d91dfcde7f776c90043e03eaa6df87e6395): 0xe7804d91dfcde7f776c90043e03eaa6df87e6395 needs to be added to the collateral currency whitelist introduced in UMIP-8.
+
+- A final fee of **800 DFX** needs to be added to the Store Contract.
+
+
+## Rationale
+
+This store fee was chosen as it is approximately equivalent to $400 in line with other collateral currencies as determined by the latest prices on CoinMarketCap and CoinGecko.
+
+## Implementation
+
+
+This change has no implementations other than the aforementioned governor transactions
+
+## Security considerations
+
+Adding a collateral currency introduces a level of risk into the UMA Ecosystem.  This collateral type should be monitored to ensure that the proposed collateral continues to have value.
+
+Contract deployers considering using this collateral in an UMA contract should refer to the [guidelines on collateral type usage](https://docs.umaproject.org/uma-tokenholders/guidence-on-collateral-currency-addition) to ensure appropriate use.
+
+

--- a/UMIPs/umip-104.md
+++ b/UMIPs/umip-104.md
@@ -24,9 +24,11 @@ The DFX token has a circulating supply of about 10,000,000 with a max supply of 
 
 To accomplish this upgrade, the following changes need to be made:
 
-The DFX token [https://etherscan.io/token/0x888888435fde8e7d4c54cab67f206e4199454c60](https://etherscan.io/token/0x888888435fde8e7d4c54cab67f206e4199454c60) needs to be added to the collateral currency whitelist introduced in UMIP-8.
+The DFX  [Ethereum token](https://etherscan.io/token/0x888888435fde8e7d4c54cab67f206e4199454c60): 0x888888435fde8e7d4c54cab67f206e4199454c60
 
-A final fee of 400 DFX needs to be added for DFX in the Store contract.
+The DFX [Polygon token](https://polygonscan.com/address/0xe7804d91dfcde7f776c90043e03eaa6df87e6395): 0xe7804d91dfcde7f776c90043e03eaa6df87e6395
+
+ Needs to be added to the collateral currency whitelist introduced in UMIP-8. A final fee of **800 DFX** needs to be added for DFX in the Store contract.
 
 ## Rationale
 Adding the DFX token as collateral (and thereby allowing the DFX community to take advantage of KPI options) advances the goal of further adoption of the UMA protocol.

--- a/UMIPs/umip-104.md
+++ b/UMIPs/umip-104.md
@@ -33,8 +33,6 @@ The DFX [Polygon token](https://polygonscan.com/address/0xe7804d91dfcde7f776c900
 ## Rationale
 Adding the DFX token as collateral (and thereby allowing the DFX community to take advantage of KPI options) advances the goal of further adoption of the UMA protocol.
 
-A final fee of 400 DFX was chosen, slightly higher than recommended, to account for price volatility of the token.
-
 ## Implementation
 
 This UMIP requires proposing the two governor transactions detailed in the above Technical Specification section.


### PR DESCRIPTION
The DFX token has already been passed in UMIP 104: https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-104.md

This UPP is here to add the DFX Polygon token to list of approved collaterals