### PR TITLE
Add the skinny OO UMIP

### DIFF
--- a/UMIPs/DRAFT_OO_UMIP.md
+++ b/UMIPs/DRAFT_OO_UMIP.md
@@ -14,8 +14,8 @@ Prior to addition of this Optimistic Oracle, it could cost millions of gas to co
 
 ## Technical Specification
 To accomplish this upgrade, a few actions will need to be taken:
-- A new `SkinnyOptimisticOracle` contract will need to be deployed. Once deployed, the contract address will be added to this UMIP.
-- A transaction will need to be proposed to add this new address to the `Finder` contract under the name `“SkinnyOptimisticOracle”`. This is how other contracts will find the optimistic oracle and reference it.
+- A new `SkinnyOptimisticOracle` contract has been deployed at [0x4060dba72344da74edaeeae51a71a57f7e96b6b4](https://etherscan.io/address/0x4060dba72344da74edaeeae51a71a57f7e96b6b4).
+- A transaction will need to be proposed to add this new address to the `Finder` contract under the name `SkinnyOptimisticOracle`. This is how other contracts will find the optimistic oracle and reference it.
 - The `SkinnyOptimisticOracle` will need to be registered with the `Registry` so that it can make requests to the DVM.
 
 Note: this change will only add the skinny optimistic oracle. New financial contracts that utilize the optimistic oracle will need to be deployed for it to become useful. Until all steps above are performed, the deployed SkinnyOptimisticOracle _should not_ be used in production since it will not be able to raise disputes to the DVM.
@@ -26,9 +26,9 @@ The `SkinnyOptimisticOracle` contract can be found [here](https://github.com/UMA
 
 The mainnet contract address:
 
-*SkinnyOptimisticOracle* - TBD (To be deployed)
+*SkinnyOptimisticOracle* - [0x4060dba72344da74edaeeae51a71a57f7e96b6b4](https://etherscan.io/address/0x4060dba72344da74edaeeae51a71a57f7e96b6b4)
 
 
 ## Security considerations
 
-Please see the individual contract for details on how each affects the security of the UMA ecosystem.
+The Optimistic Oracle only has the ability to send price requests to the DVM, so in the event of a serious bug, the biggest security implication would be that end-users would be able to send requests to the DVM without paying the final fee.


### PR DESCRIPTION
This adds a draft UMIP to register the new `SkinnyOptimisticOracle` with the DVM and finder.