### PR TITLE
fix: add r2 param

### DIFF
--- a/UMIPs/umip-136.md
+++ b/UMIPs/umip-136.md
@@ -57,11 +57,11 @@ Please see the example [implementation](https://github.com/UMAprotocol/protocol/
 
 The rates used the above computation are drawn from Aave (where applicable):
 
-| Asset | <img src="https://render.githubusercontent.com/render/math?math=\bar{U}">  | <img src="https://render.githubusercontent.com/render/math?math=R_0">  | <img src="https://render.githubusercontent.com/render/math?math=R_1">  |
-| ----- | --- | --- | --- |
-| ETH   | 65% | 0%  | 8%  |
-| USDC  | 80% | 0%  | 4%  |
-| UMA   | 50% | 0%  | 5%  |
+| Asset | <img src="https://render.githubusercontent.com/render/math?math=\bar{U}">  | <img src="https://render.githubusercontent.com/render/math?math=R_0">  | <img src="https://render.githubusercontent.com/render/math?math=R_1">  | <img src="https://render.githubusercontent.com/render/math?math=R_2">  |
+| ----- | --- | --- | --- | ---- |
+| ETH   | 65% | 0%  | 8%  | 100% |
+| USDC  | 80% | 0%  | 4%  | 100% |
+| UMA   | 50% | 0%  | 5%  | 100% |
 
 If the algorithm above doesn't produce a matching `realizedLPFeePct` (after rounding the result expressed as decimal to 18 decimals where less than 5 for the 19th decimal rounds down and 5 or above rounds up), the relay is invalid. If the token is not listed in the table above, the relay is invalid.
 

--- a/UMIPs/umip-136.md
+++ b/UMIPs/umip-136.md
@@ -60,8 +60,8 @@ The rates used the above computation are drawn from Aave (where applicable):
 | Asset | <img src="https://render.githubusercontent.com/render/math?math=\bar{U}">  | <img src="https://render.githubusercontent.com/render/math?math=R_0">  | <img src="https://render.githubusercontent.com/render/math?math=R_1">  | <img src="https://render.githubusercontent.com/render/math?math=R_2">  |
 | ----- | --- | --- | --- | ---- |
 | ETH   | 65% | 0%  | 8%  | 100% |
-| USDC  | 80% | 0%  | 4%  | 100% |
-| UMA   | 50% | 0%  | 5%  | 100% |
+| USDC  | 80% | 0%  | 4%  | 60%  |
+| UMA   | 50% | 0%  | 5%  | 200% |
 
 If the algorithm above doesn't produce a matching `realizedLPFeePct` (after rounding the result expressed as decimal to 18 decimals where less than 5 for the 19th decimal rounds down and 5 or above rounds up), the relay is invalid. If the token is not listed in the table above, the relay is invalid.
 


### PR DESCRIPTION
@cc7768 I think this is also missing in some of our other docs. We should decide what these params should be. In the bots we've been assuming that they're all 100%, so that's what I specified here.

Edit: I'm dumb. Fooled by the scrollbar.