### PR TITLE
docs: update umip-152 based on audit feedback

### DIFF
--- a/UMIPs/umip-152.md
+++ b/UMIPs/umip-152.md
@@ -125,7 +125,23 @@ The `ancillaryData` for the price request will be generated automatically and co
 
 `proposalHash: 0x...abcdef`
 
-### Resolving Disputes
+## Rationale
+It is impossible to capture every form of human organization in rigid programmatic structures. Without a flexible, natural language based system for outlining rules of operation, and a trustless and decentralized mechanism for enforcing those rules, DAOs can only exist in a stunted form, like an oak tree growing in a pot with no space for deep roots.
+
+This UMIP and the associated module code brings the flexibility of law to smart contracts, with UMA voters serving as judge and jury in case of disputes. Unlike the tradition of common law, however, UMA voters do not attempt to create precedent for ambiguous cases, resolve controversy, or fill in the gaps. If there is ambiguity about whether a particular proposal follows the rules, it is simply rejected.
+
+The onus is on the DAO to write clear rules and on the proposer to ensure their transactions follow the rules, with no room for ambiguity by a neutral third-party observer.
+
+This methodology allows for a huge amount of flexibility for DAOs to manage their shared resources without requiring UMA voters to make subjective judgements, which would be difficult for voters and could potentially create unpredictable and undesirable results for DAOs.
+
+## Implementation
+Voters should read the plain language rules referenced in the public `rules` value in the Optimistic Governor contract that requested a price and check the proposed transactions against those rules.
+
+This `rules` value will usually be an IPFS hash. If it is, voters can view the rules through a web browser by going to https://ipfs.io/ipfs/<RULES_HASH> or by using any other system to access the document using IPFS. If the `rules` value is a web URI, voters can simply enter the web URI into any web browser.
+
+The system is quite flexible, so voters may need to find other publicly verifiable data to determine if the proposed transactions follow the rules. For instance, they may need to check the result of a Snapshot vote to verify that a governance proposal was approved by the DAO token holders, or check the current price of a token to verify a proposal to make a trade according to a trading strategy outlined in the rules, or confirm public misbehavior by some address to verify a proposal to slash a bond posted by that address.
+
+If the proposer included an optional `explanation` in the ancillary data of the price request, that may be helpful for understanding the intent of the proposal, but voters should primarily consider the actual effects of the proposed transactions and verify that the transactions clearly and unambiguously follow the rules.
 
 If a proposal is disputed, the disputer is encouraged to publish their reasoning in a public forum to assist UMA voters in their determination of whether or not the proposal was valid.
 
@@ -148,17 +164,11 @@ It is the responsibility of the DAO users of the `ZODIAC` identifier to write cl
 
 It is important that the process for changing the rules be particularly clear and unambiguous, if a rule change process is allowed by the DAO. This allows the DAO to add, remove, or clarify rules as needed, analogous to a constitutional amendment.
 
-## Rationale
-It is impossible to capture every form of human organization in rigid programmatic structures. Without a flexible, natural language based system for outlining rules of operation, and a trustless and decentralized mechanism for enforcing those rules, DAOs can only exist in a stunted form, like an oak tree growing in a pot with no space for deep roots.
-
-This UMIP and the associated module code brings the flexibility of law to smart contracts, with UMA voters serving as judge and jury in case of disputes. Unlike the tradition of common law, however, UMA voters do not attempt to create precedent for ambiguous cases, resolve controversy, or fill in the gaps. If there is ambiguity about whether a particular proposal follows the rules, it is simply rejected.
-
-The onus is on the DAO to write clear rules and on the proposer to ensure their transactions follow the rules, with no room for ambiguity by a neutral third-party observer.
-
-This methodology allows for a huge amount of flexibility for DAOs to manage their shared resources without requiring UMA voters to make subjective judgements, which would be difficult for voters and could potentially create unpredictable and undesirable results for DAOs.
-
-## Implementation
 The implementation of the Optimistic Governor module can be [found here](https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/zodiac/OptimisticGovernor.sol).
+
+The requester will be the Optimistic Governor contract itself, which means voters can use the requester address to find the contract on Etherscan and inspect the public `rules` value.
+
+Voters can use the [`DecodeTransactionData` script](https://github.com/UMAprotocol/protocol/blob/master/packages/scripts/src/DecodeTransactionData.js) to decode transaction data as needed.
 
 ### Example Rules
 The `ZODIAC` identifier is designed to allow rules to be as flexible as possible while still being clear to UMA voters called in to resolve disputes. These examples are meant to inspire creativity in users creating their own rules and demonstrate the legalistic approach they should take.

--- a/UMIPs/umip-152.md
+++ b/UMIPs/umip-152.md
@@ -168,8 +168,6 @@ The implementation of the Optimistic Governor module can be [found here](https:/
 
 The requester will be the Optimistic Governor contract itself, which means voters can use the requester address to find the contract on Etherscan and inspect the public `rules` value.
 
-Voters can use the [`DecodeTransactionData` script](https://github.com/UMAprotocol/protocol/blob/master/packages/scripts/src/DecodeTransactionData.js) to decode transaction data as needed.
-
 ### Example Rules
 The `ZODIAC` identifier is designed to allow rules to be as flexible as possible while still being clear to UMA voters called in to resolve disputes. These examples are meant to inspire creativity in users creating their own rules and demonstrate the legalistic approach they should take.
 

--- a/UMIPs/umip-152.md
+++ b/UMIPs/umip-152.md
@@ -148,44 +148,6 @@ It is the responsibility of the DAO users of the `ZODIAC` identifier to write cl
 
 It is important that the process for changing the rules be particularly clear and unambiguous, if a rule change process is allowed by the DAO. This allows the DAO to add, remove, or clarify rules as needed, analogous to a constitutional amendment.
 
-### Important Special Case: Rule Changes
-
-It is possible for a bad proposal to be made that technically follows the published rules, either by a malicious actor or due to an oversight or mistake. It is also possible for the rules in an Optimistic Governor module to be changed via the existing governance process or an emergency adminstrative action by the multi-sig (if any).
-
-As a failsafe mechanism, it should be allowed for a DAO to change their rules in response to malicious proposals, and in those cases the new rules should be considered the official rules by UMA voters, and disputed proposals should be rejected if they violate the old rules, even if they technically followed the rules at the time of the original proposal.
-
-It's easiest to understand this by example.
-
-Let us consider a Magicland DAO with two rules in their published rules document:
-
-```
-1. The treasurer is allowed to move money from the treasury at their discretion for the good of the DAO.
-2. The rules can be changed by a Snapshot vote where more than 50% of the token supply votes to change the rules.
-```
-
-As it turns out, the Magicland treasurer is revealed to be a serial scam artist and proposes to move 10,000 ETH from the Magicland treasury to a smart contract wallet they controlled and then to Tornado Cash.
-
-DAO members, understandably concerned, dispute that proposal, and more than 50% of the token supply votes on Snapshot to change to new rules:
-
-```
-1. Any proposals from the former treasurer's address, 0xabc...123, are invalid and should be rejected.
-2. The rules can be changed by a Snapshot vote where more than 50% of the token supply votes to change the rules.
-```
-
-The former treasurer disputes the rules change since it would prevent them from stealing money from the treasury.
-
-The UMA voters must now consider two disputed proposal: The treasurer's proposal to move the treasury's funds to Tornado Cash and the proposal to change the rules to block the treasurer, which was approved by a majority vote on Snapshot.
-
-The voters must consider and potentially execute the rules change proposal FIRST, even though the treasurer's proposal came earlier.
-
-Since the majority of tokens voted in favor of the rules change on Snapshot, the UMA voters must return a value of `1` indicating that the rules change is valid.
-
-And, importantly, they must apply the new rules *retroactively* to the treasurer's proposal, and return a value of `0` indicating that the treasurer's proposal is invalid, even though the proposal was made before the rules were changed.
-
-This failsafe mechanism allows a DAO to change their rules when they identify a loophole or need to off-board contributors who previously had some measure of trust and personal discretion in spending DAO funds.
-
-See also: Rule Change Race Conditions, below, in `Security considerations`.
-
 ## Rationale
 It is impossible to capture every form of human organization in rigid programmatic structures. Without a flexible, natural language based system for outlining rules of operation, and a trustless and decentralized mechanism for enforcing those rules, DAOs can only exist in a stunted form, like an oak tree growing in a pot with no space for deep roots.
 
@@ -288,17 +250,6 @@ The rules may also add additional requirements for special transactions, like ch
 The reason to add these extra requirements for complex or potentially risky transactions is to make it easy for oracle observers to evaluate proposals within a short challenge window and dispute proposals that are obviously invalid.
 
 The more important a transaction is, the more requirements the DAO may want to put into their rules around that transaction. That makes it more likely that a disputer will step in to block bad proposals with confidence that they will be backed up by UMA voters since some unambiguous requirement was not fulfilled.
-
-### Rule Change Race Conditions
-A clever exploiter (see: Important Special Case) who identifies a loophole may submit a proposal shortly before the start of a new UMA voting cycle, with the expectation that their proposal will be disputed quickly and voted on in the next UMA voting cycle but a change in rules will not be made in time to block their malicious proposal.
-
-Ideally, the rules will include enough checks and balances to prevent this scenario from happening. There is a great deal of responsibility on the DAO to write safe and effective rules.
-
-But if they fail to do so and a malicious transaction comes through right before an UMA voting cycle, the DAO should consider having an extra failsafe that allows for rapid rule changes through some mechanism outside of UMA's oracle.
-
-For example, the rules may specify that they will "shut down" and become invalid if 50% of voters in an emergency Snapshot poll, or 3-of-5 signers on an emergency multi-sig, vote to invalidate them. In that scenario, UMA voters will check if the shutdown condition was triggered when evaluating a proposal.
-
-It is also possible that the DAO will have an emergency multi-sig with the power to delete proposals directly (see below).
 
 ### Continued Use of an Emergency Administrative Multi-Sig
 In the long run, it should be possible to replace multi-sig control of a Gnosis Safe, with all governance actions going through the Optimistic Governor. While the Optimistic Governor is being implemented, however, and best practices around DAO rules are being established, it may be useful to retain a multi-sig as an emergency override mechanism.


### PR DESCRIPTION
Signed-off-by: John Shutt <pemulis@users.noreply.github.com>

This pull request updates UMIP-152 for the `ZODIAC` identifier to better reflect the revised contract code, proposal/dispute/execution/deletion flows, and some additional considerations around the use of transitional administrative multi-sigs that can delete proposals in the event of an emergency.