### PR TITLE
feat(umip-157): Allow for admin bundles

### DIFF
--- a/UMIPs/umip-157.md
+++ b/UMIPs/umip-157.md
@@ -389,4 +389,4 @@ The following section describes the normal path for determining a proposed bundl
 
 The dataworker should convert these values into merkle roots in order to reconstruct a bundle. As long as "ADMIN_BUNDLE" is defined, the dataworker should mark any root bundle containing these exact roots as valid, otherwise the dataworker should follow the normal path to reconstruct roots.
 
-The admin bundle is only valid if it is proposed before the `proposalBlock` and by the `proposer` address
+The admin bundle is only valid if it is proposed before the `proposalBlock` and by the `proposer` address. The transaction in which the `ADMIN_BUNDLE` is written into the `ConfigStore` state must be mined no earlier than 600 blocks (approximately 2 hours) before the `proposalBlock`. For example, if the `ConfigStore` owner wants to set the `proposalBlock` to `16327036`, then it should only be accepted by clients if the transaction setting it so is mined after block `16326436`.


### PR DESCRIPTION
UMIP should allow for system to be able to fix errors via admin bundles in a way that doesn't give owners too much power. For example, the owner of the ConfigStore could be subject to a timelock when proposing an `ADMIN_BUNDLE` value.

Currently this new feature would give the config store owner power to propose malicious admin bundles but there are some checks on them such as a `proposalTimestamp` that the admin bundle must be proposed by and a `proposer` address restricting who can propose it.