### PR TITLE
feat(umip157): Remove `transferThreshold` from Across parameters

### DIFF
--- a/UMIPs/umip-157.md
+++ b/UMIPs/umip-157.md
@@ -299,7 +299,7 @@ if running_balance > 0:
   running_balance = 0
 # If running balance is negative, withdraw enough from the spoke to the hub to return the running balance to its target
 else if abs(running_balance) >= spoke_balance_threshold:
-  net_send_amount = min(running_balance - spoke_balance_target, 0)
+  net_send_amount = min(running_balance + spoke_balance_target, 0)
   running_balance = running_balance - net_send_amount
 ```
 

--- a/UMIPs/umip-157.md
+++ b/UMIPs/umip-157.md
@@ -296,7 +296,7 @@ net_send_amount = 0
 # If running balance is positive, then the hub owes the spoke funds.
   net_send_amount = running_balance
   running_balance = 0
-# If running balance is negative, send over enough to get running balance back to target
+# If running balance is negative, withdraw enough from the spoke to the hub to return the running balance to its target
 else if abs(running_balance) >= spoke_balance_threshold:
   net_send_amount = min(running_balance - spoke_balance_target, 0)
   running_balance = running_balance - net_send_amount

--- a/UMIPs/umip-157.md
+++ b/UMIPs/umip-157.md
@@ -293,8 +293,7 @@ spoke_balance_threshold = the "threshold" value in `spokeTargetBalances` for thi
 spoke_balance_target = the "target" value in `spokeTargetBalances` for this token
 
 net_send_amount = 0
-# If running balance is positive, then hub owes spoke funds and always send funds
-if running_balance >= 0:
+# If running balance is positive, then the hub owes the spoke funds.
   net_send_amount = running_balance
   running_balance = 0
 # If running balance is negative, send over enough to get running balance back to target

--- a/UMIPs/umip-157.md
+++ b/UMIPs/umip-157.md
@@ -294,6 +294,7 @@ spoke_balance_target = the "target" value in `spokeTargetBalances` for this toke
 
 net_send_amount = 0
 # If running balance is positive, then the hub owes the spoke funds.
+if running_balance > 0:
   net_send_amount = running_balance
   running_balance = 0
 # If running balance is negative, withdraw enough from the spoke to the hub to return the running balance to its target


### PR DESCRIPTION
Deprecated and replaced by `spokeTargetBalances` which achieves the same goal of allowing the protocol to keep excess funds on spoke pool balances in a more nuanced way