### PR TITLE
improve(UMIP179): Omit 0-value refunds and 0-value empty-message slow fills

### DIFF
--- a/UMIPs/umip-179.md
+++ b/UMIPs/umip-179.md
@@ -109,7 +109,7 @@ Across V3 defines the following new events:
 - FilledV3Relay
 
 ### V3FundsDeposited
-The `V3FundsDeposited` event emits the unique `V3RelayData` for an individual deposit. No additional fields are defined. Consumers of this event should append the `originChainId` in order to avoid unintentioanlly mixing events from different chains.
+The `V3FundsDeposited` event emits the unique `V3RelayData` for an individual deposit. No additional fields are defined. Consumers of this event should append the `originChainId` in order to avoid unintentionally mixing events from different chains.
 
 Note:
 - The `V3FundsDeposited` `outputToken` is not required to be a known HubPool `l1Token`. In-protocol arbitrary token swaps are technically supported by Across v3.
@@ -374,6 +374,7 @@ Each Relayer Refund Leaf shall be constructed as follows:
     - One entry shall exist per unique address, containing the sum of any outstanding:
         - Relayer repayments, and/or
         - Expired deposits.
+    - If the sum of the relayer repayments for a refund address is 0, then remove this entry in both arrays.
 - The `refundAddresses` and `refundAmounts` arrays shall be ordered according to the following criteria:
     1. `refundAmount` descending order, then
     2. `relayerAddress` ascending order (in case of duplicate `refundAmount` values).
@@ -394,7 +395,9 @@ Note:
 - Once these leaves are constructed, they can be used to form a merkle root as described in the previous section.
 
 ### Constructing the Slow Relay Root
-One Slow Relay Leaf shall be produced per valid `RequestedV3SlowRelay` event emitted within the target block range for a destination SpokePool.
+One Slow Relay Leaf shall be produced per valid `RequestedV3SlowFill` event emitted within the target block range for a destination SpokePool.
+
+A Slow Relay Leaf should not be produced if the `RequestedV3SlowFill` event's `inputAmount` is equal to 0 and the message is a zero bytes string.
 
 Each Slow Relay Leaf shall be constructed as follows:
 1. Set `relayData` to the `V3RelayData` data emitted by the validated `RequestedV3SlowFill` event.


### PR DESCRIPTION
These two payments out of the spoke pool will do nothing on-chain and the dataworker should not produce merkle leafs containing them.

A slow fill could technically have an input amount of 0 but have a non-empty message, for example if the message pays the filler then it still might be deemed "fillable" by the filler.