### PR TITLE
Update dead link in umip-49.md

### DIFF
--- a/UMIPs/umip-49.md
+++ b/UMIPs/umip-49.md
@@ -19,7 +19,7 @@ The DVM currently does not support the DAIPHP or PHPDAI price index. Supporting 
 Examples of a person interacting with a contract that uses this price identifier would be;
 
     - In trading pairs on Philippine cryptocurrency exchanges
-    - Basis for on chain, on demand liquidity in cross border remittance (our team is starting with the Singapore Philippine corridor with [ZkSync](https://zksync.io/faq/intro.html), [Argent](http://argent.xyz/), [SG stablecoin on ramp](https://www.xfers.com/sg/) and [PH off ramp](https://www.bloom.solutions/) who would use the synthetic Philippine Peso )
+    - Basis for on chain, on demand liquidity in cross border remittance (our team is starting with the Singapore Philippine corridor with [ZkSync](https://docs.lite.zksync.io/userdocs/intro/#introduction), [Argent](http://argent.xyz/), [SG stablecoin on ramp](https://www.xfers.com/sg/) and [PH off ramp](https://www.bloom.solutions/) who would use the synthetic Philippine Peso )
 
 More information on what we aim to achieve can be found here: [website](https://halodao.com)
 


### PR DESCRIPTION
Hi! I fixes 404 link to zksync docs:
old:
![image](https://github.com/user-attachments/assets/f75fbc7f-6114-40d0-9c96-a31342a5c319)

new:
![image](https://github.com/user-attachments/assets/19c1f7fd-eead-4c4b-8667-9ab509d274d9)
