### PR TITLE
feat(UMIP179): Change default repayment chain when No `PoolRebalanceRoute` exists for a deposit

### DIFF
--- a/UMIPs/umip-179.md
+++ b/UMIPs/umip-179.md
@@ -345,7 +345,7 @@ Each of the `Fills` emitted within the `Bundle Block Range` on a destination Spo
 3. The corresponding `Deposit` event occurred within or before the `Bundle Block Range` on the origin chain SpokePool.
 
 #### Note
-- If the `Deposit` event specifies `outputToken` `bytes32(0)` (i.e. the Zero Address), the equivalent SpokePool token on the destination chain shall be substituted in. For the purpose of determining `RelayData` equivalency, the updated/substituted `outputToken` shall be used in place of the Zero Address.
+- If the `Deposit` event specifies `outputToken` `bytes32(0)` (i.e. the Zero Address), the equivalent SpokePool token on the destination chain shall be substituted in. For the purpose of determining `RelayData` equivalency, the updated/substituted `outputToken` shall be used in place of the Zero Address. If there is no equivalent SpokePool token on the destination chain, then this deposit should not be filled by a filler.
 - `RelayData` equality can be determined by comparing the keccak256 hashes of two `RelayData` objects.
 - Fills of type `SlowFill` are valid, but are not relevant for computing relayer repayments.
 
@@ -428,7 +428,7 @@ For each validated matching `Deposit` event, the relayer repayment amount shall 
 
 The applied `repaymentChainId` shall be determined as follows:
 - When the `originChainId` is a `Lite chain` as at the `Deposit` `quoteTimestamp`: `originChainId`, ELSE
-- When no `PoolRebalanceRoute` exists for the `repaymentToken` on the `Fill` `repaymentChainId`: `destinationChainId`, ELSE
+- When no `PoolRebalanceRoute` exists for the `repaymentToken` on the `Fill` `repaymentChainId`: `originChainId`, ELSE
 - The `repaymentChainId` as specified in the `Fill`.
 
 The applied `repayment address` shall be determined as follows:


### PR DESCRIPTION
This UMIP change is required for the changes implemented in the `SpokePool` [here](https://github.com/across-protocol/contracts/commit/785dcc4f37a5e8bb922cc57b8654b27de0758886) which removes the `enabledDepositRoutes` check in the deposit() flow.