### PR TITLE
improve(179): Add caveat about lp fee = 0% when originChain == repaymentChain

### DIFF
--- a/UMIPs/umip-179.md
+++ b/UMIPs/umip-179.md
@@ -406,7 +406,7 @@ Each valid `Fill` is subject to an LP fee. The procedure for computing LP fees i
 - The AcrossConfigStore contract shall be used to identify the correct rate model, instead of a `RateModelStore` contract.
 - The `HubPool` `liquidityUtilizationCurrent()` and `liquidityUtilizationPostRelay()` functions shall be used instead of the `BridgePool` variant.
 - The event `inputToken` shall be mapped from the SpokePool address to a HubPool `l1Token` address by following the matching procedure outlined above.
-- The LP fee is computed between the `originChainId` specified by the `Deposit` and `repaymentChainId` specified by the relayer, where the `relayExecutionInfo.FillType != SlowFill` and the Fill `destinationChainId` otherwise.
+- The LP fee is computed between the `originChainId` specified by the `Deposit` and `repaymentChainId` specified by the relayer, where the `relayExecutionInfo.FillType != SlowFill` and the Fill `destinationChainId` otherwise. If the `originChainId` is equal to the `repaymentChainId` then the LP fee should be 0%.
 
 #### Note
 - The LP fee is typically referenced as a multiplier of the `Deposit` `inputAmount`, named `realizedLpFeePct` elsewhere in this document.


### PR DESCRIPTION
These deposits never utilize any LP funds so they should be charged a 0% LP fee. In practice this is what happens but we should add it to the protocol