### PR TITLE
docs(umip-157): fix "Determing" → "Determining" heading typo

### DIFF
--- a/UMIPs/umip-157.md
+++ b/UMIPs/umip-157.md
@@ -371,7 +371,7 @@ Their primary sorting index should be `originChainId` and the secondary sorting 
 
 You can then construct a merkle root similar to how it's done in the previous two sections.
 
-# Determing the Result
+# Determining the Result
 
 Three conditions must be met for the proposal to be deemed valid:
 1. The roots computed above match the ones in the proposal.


### PR DESCRIPTION
Fixes a typo in the UMIP-157 section heading: "Determing the Result" → "Determining the Result".

Beyond the spelling, this aligns the section's auto-generated anchor with the correctly-spelled links that already reference it — e.g. UMIP-179's Overview links to `umip-157.md#determining-the-result`, which currently resolves to nothing because the heading anchor was `#determing-the-result`.

Content unchanged; heading text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)